### PR TITLE
Implement proposal status change to failed or completed

### DIFF
--- a/simulation/config.py
+++ b/simulation/config.py
@@ -3,6 +3,8 @@ sentiment_decay = 0.01
 sentiment_sensitivity = 0.75
 delta_holdings_scale = 10000
 sentiment_bonus_proposal_becomes_active = 0.5
+sentiment_bonus_proposal_becomes_completed = 0.3
+sentiment_bonus_proposal_becomes_failed = -0.1
 
 # Proposal Parameters
 min_age_days = 2

--- a/simulation/policies.py
+++ b/simulation/policies.py
@@ -154,7 +154,7 @@ class ActiveProposals:
             if probability(r_failure):
                 proposals_that_will_fail.append(idx)
             elif probability(r_success):
-                proposals_that_will_succeed.append(idx)                
+                proposals_that_will_succeed.append(idx)
         return {"failed": proposals_that_will_fail, "succeeded": proposals_that_will_succeed}
 
     @staticmethod

--- a/simulation/policies.py
+++ b/simulation/policies.py
@@ -154,7 +154,7 @@ class ActiveProposals:
             if probability(r_failure):
                 proposals_that_will_fail.append(idx)
             elif probability(r_success):
-                proposals_that_will_succeed.append(idx)
+                proposals_that_will_succeed.append(idx)                    
         return {"failed": proposals_that_will_fail, "succeeded": proposals_that_will_succeed}
 
     @staticmethod
@@ -162,6 +162,9 @@ class ActiveProposals:
         network = s["network"]
         for idx in _input["failed"]:
             network.nodes[idx]["item"].status = ProposalStatus.FAILED
+
+        for idx in _input["succeeded"]:
+            network.nodes[idx]["item"].status = ProposalStatus.COMPLETED
 
         return "network", network
 
@@ -532,4 +535,48 @@ class ParticipantExits:
             for i in report:
                 print(
                     "ParticipantExits: Participant {} changed his sentiment from {} to {} because Proposal {} became active".format(i, report[i]["sentiment_old"], report[i]["sentiment_new"], report[i]["proposal_idx"]))
+        return "network", network
+
+    @staticmethod
+    def su_update_sentiment_when_proposal_becomes_failed_or_completed(params, step, sL, s, _input, **kwargs):
+        network = s["network"]
+        policy_output_passthru = s["policy_output"]
+
+        report = {}
+        for idx in policy_output_passthru["failed"]:
+            for participant_idx, proposal_idx, _ in find_in_edges_of_type_for_proposal(network, idx, "support"):
+                edge = network.edges[participant_idx, proposal_idx]
+                if edge["affinity"] == 1:
+                    sentiment_old = network.nodes[participant_idx]["item"].sentiment
+                    sentiment_new = sentiment_old + config.sentiment_bonus_proposal_becomes_failed
+                    sentiment_new = 0 if sentiment_new < 0 else sentiment_new
+                    network.nodes[participant_idx]["item"].sentiment = sentiment_new
+
+                    report[participant_idx] = {
+                        "proposal_idx": proposal_idx,
+                        "sentiment_old": sentiment_old,
+                        "sentiment_new": sentiment_new,
+                        "status": "failed"
+                    }
+        
+        for idx in policy_output_passthru["succeeded"]:
+            for participant_idx, proposal_idx, _ in find_in_edges_of_type_for_proposal(network, idx, "support"):
+                edge = network.edges[participant_idx, proposal_idx]
+                if edge["affinity"] == 1:
+                    sentiment_old = network.nodes[participant_idx]["item"].sentiment
+                    sentiment_new = sentiment_old + config.sentiment_bonus_proposal_becomes_completed
+                    sentiment_new = 1 if sentiment_new > 1 else sentiment_new
+                    network.nodes[participant_idx]["item"].sentiment = sentiment_new
+
+                    report[participant_idx] = {
+                        "proposal_idx": proposal_idx,
+                        "sentiment_old": sentiment_old,
+                        "sentiment_new": sentiment_new,
+                        "status": "completed"
+                    }
+        
+        if params.get("debug"):
+            for i in report:
+                print(
+                    "ParticipantExits: Participant {} changed his sentiment from {} to {} because Proposal {} became {}".format(i, report[i]["sentiment_old"], report[i]["sentiment_new"], report[i]["proposal_idx"], report[i]["status"]))
         return "network", network

--- a/simulation/policies.py
+++ b/simulation/policies.py
@@ -154,7 +154,7 @@ class ActiveProposals:
             if probability(r_failure):
                 proposals_that_will_fail.append(idx)
             elif probability(r_success):
-                proposals_that_will_succeed.append(idx)                    
+                proposals_that_will_succeed.append(idx)                
         return {"failed": proposals_that_will_fail, "succeeded": proposals_that_will_succeed}
 
     @staticmethod

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -190,6 +190,22 @@ partial_state_update_blocks = [
     sync_state_variables,
     {
         "policies": {
+            "which_proposals_are_failed_or_completed": ActiveProposals.p_influenced_by_grant_size
+        },
+        "variables": {
+            "network": ActiveProposals.su_set_proposal_status,
+            "policy_output": save_policy_output,
+        }
+    },
+    {
+        "policies": {},
+        "variables": {
+            "network": ParticipantExits.su_update_sentiment_when_proposal_becomes_failed_or_completed,
+        }
+    },
+    sync_state_variables,
+    {
+        "policies": {
             "participants_stake_tokens_on_proposals": ParticipantVoting.p_participant_votes_on_proposal_according_to_affinity
         },
         "variables": {

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -203,7 +203,6 @@ partial_state_update_blocks = [
             "network": ParticipantExits.su_update_sentiment_when_proposal_becomes_failed_or_completed,
         }
     },
-    sync_state_variables,
     {
         "policies": {
             "participants_stake_tokens_on_proposals": ParticipantVoting.p_participant_votes_on_proposal_according_to_affinity


### PR DESCRIPTION
This PR implements the status change of the proposals from ACTIVE to FAILED or COMPLETED, and also update the participants' sentiment by the status change of the proposals.

@randomshinichi I added the partial state update blocks of these actions right after the blocks that are updating the proposals from CANDIDATE to ACTIVE, but not sure if that is the best sequence. 