### PR TITLE
Add random state and update unit tests

### DIFF
--- a/simulation/entities.py
+++ b/simulation/entities.py
@@ -1,4 +1,3 @@
-import random
 import uuid
 from enum import Enum
 from os.path import abspath
@@ -60,14 +59,14 @@ class Proposal:
 
 
 class Participant:
-    def __init__(self, holdings: TokenBatch):
-        self.sentiment = np.random.rand()
+    def __init__(self, holdings: TokenBatch, random_state):
+        self.sentiment = random_state.rand()
         self.holdings = holdings
 
     def __repr__(self):
         return "<{} {}>".format(self.__class__.__name__, attrs(self))
 
-    def buy(self) -> float:
+    def buy(self, random_state) -> float:
         """
         If the Participant decides to buy more tokens, returns the number of
         tokens. Otherwise, return 0.
@@ -78,12 +77,12 @@ class Participant:
         """
         engagement_rate = 0.3 * self.sentiment
         force = self.sentiment - config.sentiment_sensitivity
-        if probability(engagement_rate) and force > 0:
-            delta_holdings = np.random.rand() * force * config.delta_holdings_scale
+        if probability(engagement_rate, random_state) and force > 0:
+            delta_holdings = random_state.rand() * force * config.delta_holdings_scale
             return delta_holdings
         return 0
 
-    def sell(self) -> float:
+    def sell(self, random_state) -> float:
         """
         Decides to sell some tokens, and if so how many. If the Participant
         decides to sell some tokens, returns the number of tokens. Otherwise,
@@ -95,8 +94,8 @@ class Participant:
         """
         engagement_rate = 0.3 * self.sentiment
         force = self.sentiment - config.sentiment_sensitivity
-        if probability(engagement_rate) and force < 0:
-            delta_holdings = np.random.rand() * force * self.holdings.spendable()
+        if probability(engagement_rate, random_state) and force < 0:
+            delta_holdings = random_state.rand() * force * self.holdings.spendable()
             return delta_holdings
         return 0
 
@@ -114,7 +113,7 @@ class Participant:
         """
         return self.holdings.spend(x)
 
-    def create_proposal(self, total_funds_requested, median_affinity, funding_pool) -> bool:
+    def create_proposal(self, total_funds_requested, median_affinity, funding_pool, random_state) -> bool:
         """
         Here the Participant will decide whether or not to create a new
         Proposal.
@@ -134,10 +133,10 @@ class Participant:
         percent_of_funding_pool_being_requested = total_funds_requested/funding_pool
         proposal_rate = median_affinity / \
             (1 + percent_of_funding_pool_being_requested)
-        new_proposal = probability(proposal_rate)
+        new_proposal = probability(proposal_rate, random_state)
         return new_proposal
 
-    def vote_on_candidate_proposals(self, candidate_proposals: dict) -> dict:
+    def vote_on_candidate_proposals(self, candidate_proposals: dict, random_state) -> dict:
         """
         Here the Participant decides which Candidate Proposals he will stake
         tokens on. This method does not decide how many tokens he will stake
@@ -161,7 +160,7 @@ class Participant:
         """
         new_voted_proposals = {}
         engagement_rate = 1.0
-        if probability(engagement_rate):
+        if probability(engagement_rate, random_state):
             # Put your tokens on your favourite Proposals, where favourite is
             # calculated as 0.75 * (the affinity for the Proposal you like the
             # most) e.g. if there are 2 Proposals that you have affinity 0.8,
@@ -205,12 +204,12 @@ class Participant:
 
         return tokens_per_supported_proposal
 
-    def wants_to_exit(self):
+    def wants_to_exit(self, random_state):
         """
         Returns True if the Participant wants to exit (if sentiment < 0.5,
         random chance of exiting), otherwise False
         """
         if self.sentiment < 0.5:
             engagement_rate = 0.3 * self.sentiment
-            return probability(1-engagement_rate)
+            return probability(1-engagement_rate, random_state)
         return False

--- a/simulation/entities.py
+++ b/simulation/entities.py
@@ -60,9 +60,9 @@ class Proposal:
 
 class Participant:
     def __init__(self, holdings: TokenBatch, probability_func, random_number_func):
-        self._probability = probability_func
-        self._random_number = random_number_func
-        self.sentiment = self._random_number()
+        self._probability_func = probability_func
+        self._random_number_func = random_number_func
+        self.sentiment = self._random_number_func()
         self.holdings = holdings
 
     def __repr__(self):
@@ -79,8 +79,8 @@ class Participant:
         """
         engagement_rate = 0.3 * self.sentiment
         force = self.sentiment - config.sentiment_sensitivity
-        if self._probability(engagement_rate) and force > 0:
-            delta_holdings = self._random_number() * force * config.delta_holdings_scale
+        if self._probability_func(engagement_rate) and force > 0:
+            delta_holdings = self._random_number_func() * force * config.delta_holdings_scale
             return delta_holdings
         return 0
 
@@ -96,8 +96,8 @@ class Participant:
         """
         engagement_rate = 0.3 * self.sentiment
         force = self.sentiment - config.sentiment_sensitivity
-        if self._probability(engagement_rate) and force < 0:
-            delta_holdings = self._random_number() * force * self.holdings.spendable()
+        if self._probability_func(engagement_rate) and force < 0:
+            delta_holdings = self._random_number_func() * force * self.holdings.spendable()
             return delta_holdings
         return 0
 
@@ -135,7 +135,7 @@ class Participant:
         percent_of_funding_pool_being_requested = total_funds_requested/funding_pool
         proposal_rate = median_affinity / \
             (1 + percent_of_funding_pool_being_requested)
-        new_proposal = self._probability(proposal_rate)
+        new_proposal = self._probability_func(proposal_rate)
         return new_proposal
 
     def vote_on_candidate_proposals(self, candidate_proposals: dict) -> dict:
@@ -162,7 +162,7 @@ class Participant:
         """
         new_voted_proposals = {}
         engagement_rate = 1.0
-        if self._probability(engagement_rate):
+        if self._probability_func(engagement_rate):
             # Put your tokens on your favourite Proposals, where favourite is
             # calculated as 0.75 * (the affinity for the Proposal you like the
             # most) e.g. if there are 2 Proposals that you have affinity 0.8,
@@ -213,5 +213,5 @@ class Participant:
         """
         if self.sentiment < 0.5:
             engagement_rate = 0.3 * self.sentiment
-            return self._probability(1-engagement_rate)
+            return self._probability_func(1-engagement_rate)
         return False

--- a/simulation/entities_test.py
+++ b/simulation/entities_test.py
@@ -9,11 +9,14 @@ from entities import Participant, Proposal, ProposalStatus
 from hatch import TokenBatch, VestingOptions
 from simulation import new_probability_func, new_random_number_func
 
+
 def always(rate):
     return True
 
+
 def never(rate):
     return False
+
 
 class TestProposal(unittest.TestCase):
     def test_has_enough_conviction(self):
@@ -27,13 +30,13 @@ class TestProposal(unittest.TestCase):
 
 
 class TestParticipant(unittest.TestCase):
-    def setUp(self, ):
+    def setUp(self):
         self.params = {
             "probability_func": new_probability_func(seed=None),
             "random_number_func": new_random_number_func(seed=None)
         }
         self.p = Participant(TokenBatch(100, 100), self.params["probability_func"], self.params["random_number_func"])
-    
+
     def test_buy(self):
         """
         Test that the function works. If we set the probability to 1, Participant should buy in.
@@ -42,11 +45,11 @@ class TestParticipant(unittest.TestCase):
 
         # Must set Participant's sentiment artificially high, because of Zargham's force calculation
         self.p.sentiment = 1
-        self.p._probability = always
+        self.p._probability_func = always
         delta_holdings = self.p.buy()
         self.assertGreater(delta_holdings, 0)
 
-        self.p._probability = never
+        self.p._probability_func = never
         delta_holdings = self.p.buy()
         self.assertEqual(delta_holdings, 0)
 
@@ -56,12 +59,12 @@ class TestParticipant(unittest.TestCase):
         If we set the probability to 0, 0 will be returned.
         """
 
-        self.p._probability = always
+        self.p._probability_func = always
         self.p.sentiment = 0.1
         delta_holdings = self.p.sell()
         self.assertLess(delta_holdings, 0)
 
-        self.p._probability = never
+        self.p._probability_func = never
         delta_holdings = self.p.sell()
         self.assertEqual(delta_holdings, 0)
 
@@ -71,10 +74,10 @@ class TestParticipant(unittest.TestCase):
         get True. If not, we should get False.
         """
 
-        self.p._probability = always
+        self.p._probability_func = always
         self.assertTrue(self.p.create_proposal(10000, 0.5, 100000))
 
-        self.p._probability = never
+        self.p._probability_func = never
         self.assertFalse(self.p.create_proposal(10000, 0.5, 100000))
 
     def test_vote_on_candidate_proposals(self):
@@ -83,17 +86,17 @@ class TestParticipant(unittest.TestCase):
         get a dict of Proposal UUIDs that the Participant would vote on. If not,
         we should get an empty dict.
         """
-        
+
         candidate_proposals = {
             0: 1.0,
             1: 1.0,
             2: 1.0,
         }
-        self.p._probability = never
+        self.p._probability_func = never
         ans = self.p.vote_on_candidate_proposals(candidate_proposals)
         self.assertFalse(ans)
 
-        self.p._probability = always
+        self.p._probability_func = always
         ans = self.p.vote_on_candidate_proposals(candidate_proposals)
         self.assertEqual(len(ans), 3)
 
@@ -113,7 +116,7 @@ class TestParticipant(unittest.TestCase):
             2: 0.8,
             3: 0.4,
         }
-        self.p._probability = always
+        self.p._probability_func = always
         ans = self.p.vote_on_candidate_proposals(candidate_proposals)
         reference = {
             0: 1.0,

--- a/simulation/network_utils.py
+++ b/simulation/network_utils.py
@@ -3,7 +3,6 @@ from typing import Dict, List, Tuple
 import networkx as nx
 import numpy as np
 from networkx.classes.reportviews import NodeDataView
-from scipy.stats import expon, gamma
 
 from convictionvoting import trigger_threshold
 from entities import Participant, Proposal, ProposalStatus
@@ -50,34 +49,34 @@ def get_participants(network: nx.DiGraph) -> NodeDataView:
     return view.nodes(data="item")
 
 
-def add_proposal(network: nx.DiGraph, p: Proposal,random_state) -> Tuple[nx.DiGraph, int]:
+def add_proposal(network: nx.DiGraph, p: Proposal, random_number_func) -> Tuple[nx.DiGraph, int]:
     j = max(network.nodes) + 1
     network.add_node(j, item=p)
-    network = setup_support_edges(network, random_state, j)
+    network = setup_support_edges(network, random_number_func, j)
     return network, j
 
 
-def add_participant(network: nx.DiGraph, p: Participant, random_state) -> Tuple[nx.DiGraph, int]:
+def add_participant(network: nx.DiGraph, p: Participant, exponential_func, random_number_func) -> Tuple[nx.DiGraph, int]:
     j = max(network.nodes) + 1
     network.add_node(j, item=p)
-    network = setup_influence_edges_single(network, j, random_state)
-    network = setup_support_edges(network, random_state, j)
+    network = setup_influence_edges_single(network, j, exponential_func)
+    network = setup_support_edges(network, random_number_func, j)
     return network, j
 
 
-def create_network(token_batches: List[TokenBatch], random_state) -> nx.DiGraph:
+def create_network(token_batches: List[TokenBatch], probability_func, random_number_func) -> nx.DiGraph:
     """
     Creates a new DiGraph with Participants corresponding to the input
     TokenBatches.
     """
     network = nx.DiGraph()
     for i, tb in enumerate(token_batches):
-        p_instance = Participant(tb, random_state)
+        p_instance = Participant(tb, probability_func, random_number_func)
         network.add_node(i, item=p_instance)
     return network
 
 
-def influence(random_state, scale=1, sigmas=3):
+def influence(exponential_func, scale=1, sigmas=3):
     """
     Calculates the likelihood of one node having influence over another node. If
     so, it returns an influence value, else None.
@@ -93,13 +92,13 @@ def influence(random_state, scale=1, sigmas=3):
     that adds new Participants later on can share this code.
     """
 
-    influence_rv = expon.rvs(loc=0.0, scale=scale, random_state=random_state)
+    influence_rv = exponential_func(loc=0.0, scale=scale)
     if influence_rv > scale+sigmas*scale**2:
         return influence_rv
     return None
 
 
-def setup_influence_edges_bulk(network: nx.DiGraph, random_state) -> nx.DiGraph:
+def setup_influence_edges_bulk(network: nx.DiGraph, exponential_func) -> nx.DiGraph:
     """
     Calculates the chances that a Participant is influential enough to have an
     'influence' edge in the network to other Participants, and creates the
@@ -118,14 +117,14 @@ def setup_influence_edges_bulk(network: nx.DiGraph, random_state) -> nx.DiGraph:
     for i in participants:
         for other_participant in participants:
             if not(other_participant == i) and not network.has_edge(i, other_participant):
-                influence_rv = influence(random_state)
+                influence_rv = influence(exponential_func)
                 if influence_rv:
                     network.add_edge(i, other_participant,
                                      influence=influence_rv, type="influence")
     return network
 
 
-def setup_influence_edges_single(network: nx.DiGraph, participant: int, random_state):
+def setup_influence_edges_single(network: nx.DiGraph, participant: int, exponential_func):
     p = dict(get_participants(network))
     del p[participant]
     other_participants = p
@@ -134,19 +133,19 @@ def setup_influence_edges_single(network: nx.DiGraph, participant: int, random_s
     # Participant at index 5, this creates the edges 0,5; 1,5; 2;5 etc.
     for other in other_participants:
         if not network.has_edge(other, participant):
-            influence_rv = influence(random_state)
+            influence_rv = influence(exponential_func)
             if influence_rv:
                 network.add_edge(other, participant,
                                  influence=influence_rv, type="influence")
         if not network.has_edge(participant, other):
-            influence_rv = influence(random_state)
+            influence_rv = influence(exponential_func)
             if influence_rv:
                 network.add_edge(participant, other,
                                  influence=influence_rv, type="influence")
     return network
 
 
-def setup_conflict_edges(network: nx.DiGraph, random_state, proposal=None, rate=.25) -> nx.DiGraph:
+def setup_conflict_edges(network: nx.DiGraph, random_number_func, proposal=None, rate=.25) -> nx.DiGraph:
     """
     Supporting one Proposal may mean going against another Proposal, in which
     case a Proposal-Proposal conflict edge is created. This function calculates
@@ -156,13 +155,13 @@ def setup_conflict_edges(network: nx.DiGraph, random_state, proposal=None, rate=
     Proposal in network.nodes. If this argument is present, it will setup the
     conflict edges only for this Proposal.
     """
-    def loop_over_other_proposals(network, proposals, proposal, random_state):
+    def loop_over_other_proposals(network, proposals, proposal, random_number_func):
         for other_proposal in proposals:
             if not(other_proposal == proposal):
                 # (rate=0.25) means 25% of other Proposals are going to conflict
                 # with this particular Proposal. And when they do conflict, the
                 # conflict number is high (at least 1 - 0.25 = 0.75).
-                conflict_rv = random_state.rand()
+                conflict_rv = random_number_func()
                 if conflict_rv < rate:
                     network.add_edge(proposal, other_proposal)
                     network.edges[(proposal, other_proposal)
@@ -178,12 +177,12 @@ def setup_conflict_edges(network: nx.DiGraph, random_state, proposal=None, rate=
     # Do not use "if not proposal" - index number 0 will evaluate to False.
     if proposal is None:
         for i in proposals:
-            network = loop_over_other_proposals(network, proposals, i, random_state)
+            network = loop_over_other_proposals(network, proposals, i, random_number_func)
         return network
-    return loop_over_other_proposals(network, proposals, proposal, random_state)
+    return loop_over_other_proposals(network, proposals, proposal, random_number_func)
 
 
-def setup_support_edges(network: nx.DiGraph, random_state, idx=None) -> nx.DiGraph:
+def setup_support_edges(network: nx.DiGraph, random_number_func, idx=None) -> nx.DiGraph:
     """
     Every Participant has a 'support' edge to every Proposal, and vice versa,
     indicating how much that Participant supports that Proposal. This function
@@ -193,13 +192,13 @@ def setup_support_edges(network: nx.DiGraph, random_state, idx=None) -> nx.DiGra
     support edges to other Proposal nodes and vice versa if the node is a
     Proposal.
     """
-    def create_support_edge(n, i, j, random_state):
+    def create_support_edge(n, i, j, random_number_func):
         # Token Holder -> Proposal Relationship
         # Looks like Zargham skewed this distribution heavily towards
         # numbers smaller than 0.25 This is the affinity towards proposals.
         # Most Participants won't care about most proposals, but then there
         # will be a few Proposals that they really care about.
-        rv = random_state.rand()
+        rv = random_number_func()
         a_rv = 1-4*(1-rv)*rv
         n.add_edge(i, j, affinity=a_rv, tokens=0, conviction=0, type="support")
         return n
@@ -209,34 +208,34 @@ def setup_support_edges(network: nx.DiGraph, random_state, idx=None) -> nx.DiGra
     if idx is None:
         for prop in proposals:
             for par in participants:
-                network = create_support_edge(network, par, prop, random_state)
+                network = create_support_edge(network, par, prop, random_number_func)
 
     else:
         if isinstance(network.nodes[idx]['item'], Proposal):
             for par in participants:
-                network = create_support_edge(network, par, idx, random_state)
+                network = create_support_edge(network, par, idx, random_number_func)
         elif isinstance(network.nodes[idx]['item'], Participant):
             for prop in proposals:
-                network = create_support_edge(network, idx, prop, random_state)
+                network = create_support_edge(network, idx, prop, random_number_func)
     return network
 
 
-def bootstrap_network(n_participants: List[TokenBatch], n_proposals: int, funding_pool: float, token_supply: float, max_proposal_request: float, random_state) -> nx.DiGraph:
+def bootstrap_network(n_participants: List[TokenBatch], n_proposals: int, funding_pool: float, token_supply: float, max_proposal_request: float, probability_func, random_number_func, gamma_func, exponential_func) -> nx.DiGraph:
     """
     Convenience function that creates a network ready for simulation in
     the Python notebook in one line.
     """
-    n = create_network(n_participants, random_state)
+    n = create_network(n_participants, probability_func, random_number_func)
 
     for _ in range(n_proposals):
         idx = len(n)
-        r_rv = gamma.rvs(3, loc=0.001, scale=10000, random_state=random_state)
+        r_rv = gamma_func(3, loc=0.001, scale=10000)
         n.add_node(idx, item=Proposal(funds_requested=r_rv, trigger=trigger_threshold(
             r_rv, funding_pool, token_supply, max_proposal_request)))
 
-    n = setup_support_edges(n, random_state)
-    n = setup_conflict_edges(n, random_state)
-    n = setup_influence_edges_bulk(n, random_state)
+    n = setup_support_edges(n, random_number_func)
+    n = setup_conflict_edges(n, random_number_func)
+    n = setup_influence_edges_bulk(n, exponential_func)
     return n
 
 

--- a/simulation/network_utils_test.py
+++ b/simulation/network_utils_test.py
@@ -26,7 +26,7 @@ class TestNetworkUtils(unittest.TestCase):
         }
 
         for i in range(0, 10, 2):
-            self.network.add_node(i, item=Participant(TokenBatch(0, 0), self.params["probability_func"], 
+            self.network.add_node(i, item=Participant(TokenBatch(0, 0), self.params["probability_func"],
                                 self.params["random_number_func"]))
             self.network.add_node(i+1, item=Proposal(10, 5))
 
@@ -265,7 +265,7 @@ class TestNetworkUtils(unittest.TestCase):
         particular node.
         """
         n1, j = add_participant(self.network,
-                                Participant(TokenBatch(0, 0), self.params["probability_func"], 
+                                Participant(TokenBatch(0, 0), self.params["probability_func"],
                                 self.params["random_number_func"]), self.params["exponential_func"],
                                 self.params["random_number_func"])
         self.assertIsInstance(n1.nodes[j]["item"], Participant)

--- a/simulation/network_utils_test.py
+++ b/simulation/network_utils_test.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from entities import Participant, Proposal, ProposalStatus
 from hatch import TokenBatch, VestingOptions
-from simulation import new_probability_func, new_exponential_func, new_gamma_func, new_random_number_func
+from utils import new_probability_func, new_exponential_func, new_gamma_func, new_random_number_func
 from network_utils import (add_proposal, add_participant, bootstrap_network, calc_avg_sentiment,
                            calc_median_affinity, calc_total_affinity, calc_total_conviction,
                            calc_total_funds_requested, find_in_edges_of_type_for_proposal, get_edges_by_type, get_edges_by_participant_and_type,

--- a/simulation/policies_test.py
+++ b/simulation/policies_test.py
@@ -154,7 +154,7 @@ class TestGenerateNewProposal(unittest.TestCase):
 class TestGenerateNewFunding(unittest.TestCase):
     def setUp(self):
         self.params = {"exponential_func": new_exponential_func(seed=None)}
-    
+
     def test_p_exit_tribute_of_average_speculator_position_size(self):
         """
         Simply test that the code works.

--- a/simulation/policies_test.py
+++ b/simulation/policies_test.py
@@ -7,7 +7,7 @@ import numpy as np
 
 import networkx as nx
 
-from simulation import new_probability_func, new_exponential_func, new_gamma_func, new_random_number_func, new_choice_func
+from utils import new_probability_func, new_exponential_func, new_gamma_func, new_random_number_func, new_choice_func
 from entities import Proposal, ProposalStatus
 from hatch import Commons, TokenBatch, VestingOptions
 from network_utils import (add_proposal, bootstrap_network,

--- a/simulation/policies_test.py
+++ b/simulation/policies_test.py
@@ -7,6 +7,7 @@ import numpy as np
 
 import networkx as nx
 
+from simulation import new_probability_func, new_exponential_func, new_gamma_func, new_random_number_func, new_choice_func
 from entities import Proposal, ProposalStatus
 from hatch import Commons, TokenBatch, VestingOptions
 from network_utils import (add_proposal, bootstrap_network,
@@ -19,13 +20,29 @@ from policies import (ActiveProposals, GenerateNewFunding,
                       ProposalFunding)
 
 
+def always(rate):
+    return True
+
+
+def never(rate):
+    return False
+
+
 class TestGenerateNewParticipant(unittest.TestCase):
     def setUp(self):
         self.commons = Commons(10000, 1000)
         self.sentiment = 0.5
-        self.params = {"debug": False, "random_state": np.random.RandomState(None)}
+        self.params = {
+            "debug": False,
+            "probability_func": new_probability_func(seed=None),
+            "exponential_func": new_exponential_func(seed=None),
+            "gamma_func": new_gamma_func(seed=None),
+            "random_number_func": new_random_number_func(seed=None)
+        }
         self.network = bootstrap_network([TokenBatch(1000, 0, vesting_options=VestingOptions(10, 30))
-                                          for _ in range(4)], 1, 3000, 4e6, 0.2, self.params["random_state"])
+                                          for _ in range(4)], 1, 3000, 4e6, 0.2, self.params["probability_func"],
+                                          self.params["random_number_func"], self.params["gamma_func"],
+                                          self.params["exponential_func"])
 
     def test_p_randomly(self):
         """
@@ -35,12 +52,11 @@ class TestGenerateNewParticipant(unittest.TestCase):
             "commons": self.commons,
             "sentiment": self.sentiment
         }
-        with patch("policies.probability") as p:
-            p.return_value = True
-            ans = GenerateNewParticipant.p_randomly(self.params, 0, 0, state)
-            self.assertEqual(ans["new_participant"], True)
-            self.assertIsNotNone(ans["new_participant_investment"])
-            self.assertIsNotNone(ans["new_participant_tokens"])
+        self.params["probability_func"] = always
+        ans = GenerateNewParticipant.p_randomly(self.params, 0, 0, state)
+        self.assertEqual(ans["new_participant"], True)
+        self.assertIsNotNone(ans["new_participant_investment"])
+        self.assertIsNotNone(ans["new_participant_tokens"])
 
     def test_su_add_to_network(self):
         """
@@ -77,15 +93,24 @@ class TestGenerateNewParticipant(unittest.TestCase):
 
 class TestGenerateNewProposal(unittest.TestCase):
     def setUp(self):
-        self.params = {"max_proposal_request": 0.2, "random_state": np.random.RandomState(None)}
+        self.params = {
+            "max_proposal_request": 0.2,
+            "probability_func": new_probability_func(seed=None),
+            "exponential_func": new_exponential_func(seed=None),
+            "gamma_func": new_gamma_func(seed=None),
+            "random_number_func": new_random_number_func(seed=None),
+            "choice_func": new_choice_func(seed=None)
+        }
         self.network = bootstrap_network([TokenBatch(1000, 0, vesting_options=VestingOptions(10, 30))
-                                          for _ in range(4)], 1, 3000, 4e6, 0.2, self.params["random_state"])
+                                          for _ in range(4)], 1, 3000, 4e6, 0.2, self.params["probability_func"],
+                                          self.params["random_number_func"], self.params["gamma_func"],
+                                          self.params["exponential_func"])
 
     def test_p_randomly(self):
         """
         Simply test that the code runs.
         """
-        with patch("entities.probability") as p:
+        with patch("entities.Participant.create_proposal") as p:
             p.return_value = True
             ans = GenerateNewProposal.p_randomly(
                 self.params, 0, 0, {"network": self.network, "funding_pool": 100000})
@@ -94,7 +119,7 @@ class TestGenerateNewProposal(unittest.TestCase):
 
             p.return_value = False
             ans = GenerateNewProposal.p_randomly(
-                self.params, 0, 0, {"network": self.network, "funding_pool": 100000})
+            self.params, 0, 0, {"network": self.network, "funding_pool": 100000})
             self.assertFalse(ans["new_proposal"])
 
     def test_su_add_to_network(self):
@@ -128,7 +153,7 @@ class TestGenerateNewProposal(unittest.TestCase):
 
 class TestGenerateNewFunding(unittest.TestCase):
     def setUp(self):
-        self.params = {"random_state": np.random.RandomState(None)}
+        self.params = {"exponential_func": new_exponential_func(seed=None)}
     
     def test_p_exit_tribute_of_average_speculator_position_size(self):
         """
@@ -152,11 +177,18 @@ class TestGenerateNewFunding(unittest.TestCase):
 
 class TestActiveProposals(unittest.TestCase):
     def setUp(self):
-        self.params = {"random_state": np.random.RandomState(None)}
+        self.params = {
+            "probability_func": new_probability_func(seed=None),
+            "exponential_func": new_exponential_func(seed=None),
+            "gamma_func": new_gamma_func(seed=None),
+            "random_number_func": new_random_number_func(seed=None)
+        }
         self.network = bootstrap_network([TokenBatch(1000, 0, vesting_options=VestingOptions(10, 30))
-                                          for _ in range(4)], 1, 3000, 4e6, 0.2, self.params["random_state"])
+                                          for _ in range(4)], 1, 3000, 4e6, 0.2, self.params["probability_func"],
+                                          self.params["random_number_func"], self.params["gamma_func"],
+                                          self.params["exponential_func"])
 
-        self.network, _ = add_proposal(self.network, Proposal(100, 1), self.params["random_state"])
+        self.network, _ = add_proposal(self.network, Proposal(100, 1), self.params["random_number_func"])
 
         self.network.nodes[4]["item"].status = ProposalStatus.ACTIVE
         self.network.nodes[5]["item"].status = ProposalStatus.ACTIVE
@@ -165,12 +197,11 @@ class TestActiveProposals(unittest.TestCase):
         """
         Simply test that the code works.
         """
-        with patch("policies.probability") as p:
-            p.return_value = True
-            ans = ActiveProposals.p_influenced_by_grant_size(
-                self.params, 0, 0, {"network": copy.copy(self.network)})
+        self.params["probability_func"] = always
+        ans = ActiveProposals.p_influenced_by_grant_size(
+            self.params, 0, 0, {"network": copy.copy(self.network)})
 
-            self.assertEqual(ans["failed"], [4, 5])
+        self.assertEqual(ans["failed"], [4, 5])
 
     def test_su_set_proposal_status(self):
         """
@@ -189,12 +220,17 @@ class TestProposalFunding(unittest.TestCase):
         self.params = {
             "max_proposal_request": 0.2,
             "alpha_days_to_80p_of_max_voting_weight": 10,
-            "random_state": np.random.RandomState(None)
+            "probability_func": new_probability_func(seed=None),
+            "exponential_func": new_exponential_func(seed=None),
+            "gamma_func": new_gamma_func(seed=None),
+            "random_number_func": new_random_number_func(seed=None)
         }
         self.network = bootstrap_network([TokenBatch(1000, 0, vesting_options=VestingOptions(10, 30))
-                                          for _ in range(4)], 1, 3000, 4e6, 0.2, self.params["random_state"])
+                                          for _ in range(4)], 1, 3000, 4e6, 0.2, self.params["probability_func"],
+                                          self.params["random_number_func"], self.params["gamma_func"],
+                                          self.params["exponential_func"])
 
-        self.network, _ = add_proposal(self.network, Proposal(100, 1), self.params["random_state"])
+        self.network, _ = add_proposal(self.network, Proposal(100, 1), self.params["random_number_func"])
 
         self.network.nodes[4]["item"].status = ProposalStatus.CANDIDATE
         self.network.nodes[5]["item"].status = ProposalStatus.CANDIDATE
@@ -255,12 +291,17 @@ class TestParticipantVoting(unittest.TestCase):
         self.params = {
             "debug": False,
             "days_to_80p_of_max_voting_weight": 10,
-            "random_state": np.random.RandomState(None)
+            "probability_func": new_probability_func(seed=None),
+            "exponential_func": new_exponential_func(seed=None),
+            "gamma_func": new_gamma_func(seed=None),
+            "random_number_func": new_random_number_func(seed=None)
         }
         self.network = bootstrap_network([TokenBatch(1000, 0, vesting_options=VestingOptions(10, 30))
-                                          for _ in range(4)], 1, 3000, 4e6, 0.2, self.params["random_state"])
+                                          for _ in range(4)], 1, 3000, 4e6, 0.2, self.params["probability_func"],
+                                          self.params["random_number_func"], self.params["gamma_func"],
+                                          self.params["exponential_func"])
 
-        self.network, _ = add_proposal(self.network, Proposal(100, 1), self.params["random_state"])
+        self.network, _ = add_proposal(self.network, Proposal(100, 1), self.params["random_number_func"])
 
         """
         For proper testing, we need to make sure the Proposals are CANDIDATE and
@@ -277,19 +318,18 @@ class TestParticipantVoting(unittest.TestCase):
         Ensure that when a Participant votes on 2 Proposals of equal affinity,
         he will split his tokens 50-50 between them.
         """
-        with patch("entities.probability") as p:
-            p.return_value = True
-            ans = ParticipantVoting.p_participant_votes_on_proposal_according_to_affinity(
-                self.params, 0, 0, {"network": copy.copy(self.network), "funding_pool": 1000, "token_supply": 1000})
+        self.params["probability_func"] = always
+        ans = ParticipantVoting.p_participant_votes_on_proposal_according_to_affinity(
+            self.params, 0, 0, {"network": copy.copy(self.network), "funding_pool": 1000, "token_supply": 1000})
 
-            reference = {
-                'participants_stake_on_proposals': {0: {4: 500.0, 5: 500.0},
-                                                    1: {4: 500.0, 5: 500.0},
-                                                    2: {4: 500.0, 5: 500.0},
-                                                    3: {4: 500.0, 5: 500.0}
-                                                    }
-            }
-            self.assertEqual(ans, reference)
+        reference = {
+            'participants_stake_on_proposals': {0: {4: 500.0, 5: 500.0},
+                                                1: {4: 500.0, 5: 500.0},
+                                                2: {4: 500.0, 5: 500.0},
+                                                3: {4: 500.0, 5: 500.0}
+                                                }
+        }
+        self.assertEqual(ans, reference)
 
     def test_p_participant_votes_on_proposal_according_to_affinity_vesting_nonvesting(self):
         """
@@ -301,29 +341,36 @@ class TestParticipantVoting(unittest.TestCase):
         for _, participant in participants:
             participant.holdings = TokenBatch(1000, 1000)
 
-        with patch("entities.probability") as p:
-            p.return_value = True
-            ans = ParticipantVoting.p_participant_votes_on_proposal_according_to_affinity(
-                self.params, 0, 0, {"network": copy.copy(self.network), "funding_pool": 1000, "token_supply": 1000})
+        self.params["probability_func"] = always
+        ans = ParticipantVoting.p_participant_votes_on_proposal_according_to_affinity(
+            self.params, 0, 0, {"network": copy.copy(self.network), "funding_pool": 1000, "token_supply": 1000})
 
-            reference = {
-                'participants_stake_on_proposals': {0: {4: 1000.0, 5: 1000.0},
-                                                    1: {4: 1000.0, 5: 1000.0},
-                                                    2: {4: 1000.0, 5: 1000.0},
-                                                    3: {4: 1000.0, 5: 1000.0}
-                                                    }
-            }
-            self.assertEqual(ans, reference)
+        reference = {
+            'participants_stake_on_proposals': {0: {4: 1000.0, 5: 1000.0},
+                                                1: {4: 1000.0, 5: 1000.0},
+                                                2: {4: 1000.0, 5: 1000.0},
+                                                3: {4: 1000.0, 5: 1000.0}
+                                                }
+        }
+        self.assertEqual(ans, reference)
 
 
 class TestParticipantBuysTokens(unittest.TestCase):
     def setUp(self):
-        self.params = {"debug": True, "random_state": np.random.RandomState(None)}
+        self.params = {
+            "debug": True,
+            "probability_func": new_probability_func(seed=None),
+            "exponential_func": new_exponential_func(seed=None),
+            "gamma_func": new_gamma_func(seed=None),
+            "random_number_func": new_random_number_func(seed=None)
+        }
         self.network = bootstrap_network([TokenBatch(1000, 1000, vesting_options=VestingOptions(10, 30))
-                                          for _ in range(4)], 1, 3000, 4e6, 0.2, self.params["random_state"])
+                                          for _ in range(4)], 1, 3000, 4e6, 0.2, self.params["probability_func"],
+                                          self.params["random_number_func"], self.params["gamma_func"],
+                                          self.params["exponential_func"])
         self.commons = Commons(1000, 1000)
 
-        self.network, _ = add_proposal(self.network, Proposal(100, 1), self.params["random_state"])
+        self.network, _ = add_proposal(self.network, Proposal(100, 1), self.params["random_number_func"])
         self.default_state = {"network": self.network, "commons": self.commons,
                               "funding_pool": 1000, "token_supply": 1000}
 
@@ -405,13 +452,18 @@ class TestParticipantSellsTokens(unittest.TestCase):
     def setUp(self):
         self.params = {
             "debug": False,
-            "random_state": np.random.RandomState(None),
+            "probability_func": new_probability_func(seed=None),
+            "exponential_func": new_exponential_func(seed=None),
+            "gamma_func": new_gamma_func(seed=None),
+            "random_number_func": new_random_number_func(seed=None)
         }
         self.network = bootstrap_network([TokenBatch(1000, 1000, vesting_options=VestingOptions(10, 30))
-                                          for _ in range(4)], 1, 3000, 4e6, 0.2, self.params["random_state"])
+                                          for _ in range(4)], 1, 3000, 4e6, 0.2, self.params["probability_func"],
+                                          self.params["random_number_func"], self.params["gamma_func"],
+                                          self.params["exponential_func"])
         self.commons = Commons(1000, 1000)
 
-        self.network, _ = add_proposal(self.network, Proposal(100, 1), self.params["random_state"])
+        self.network, _ = add_proposal(self.network, Proposal(100, 1), self.params["random_number_func"])
         self.default_state = {"network": self.network, "commons": self.commons,
                               "funding_pool": 1000, "token_supply": 1000}
 
@@ -489,12 +541,20 @@ class TestParticipantSellsTokens(unittest.TestCase):
 
 class TestParticipantExits(unittest.TestCase):
     def setUp(self):
-        self.params = {"debug": True, "random_state": np.random.RandomState(None)}
+        self.params = {
+            "debug": True,
+            "probability_func": new_probability_func(seed=None),
+            "exponential_func": new_exponential_func(seed=None),
+            "gamma_func": new_gamma_func(seed=None),
+            "random_number_func": new_random_number_func(seed=None)
+        }
         self.network = bootstrap_network([TokenBatch(1000, 1000, vesting_options=VestingOptions(10, 30))
-                                          for _ in range(4)], 1, 3000, 4e6, 0.2, self.params["random_state"])
+                                          for _ in range(4)], 1, 3000, 4e6, 0.2, self.params["probability_func"],
+                                          self.params["random_number_func"], self.params["gamma_func"],
+                                          self.params["exponential_func"])
         self.commons = Commons(1000, 1000)
 
-        self.network, _ = add_proposal(self.network, Proposal(100, 1), self.params["random_state"])
+        self.network, _ = add_proposal(self.network, Proposal(100, 1), self.params["random_number_func"])
         self.default_state = {"network": self.network, "commons": self.commons,
                               "funding_pool": 1000, "token_supply": 1000}
 
@@ -503,12 +563,11 @@ class TestParticipantExits(unittest.TestCase):
         for i, participant in participants:
             participant.sentiment = 0.1
 
-        with patch("entities.probability") as p:
-            p.return_value = True
-            ans = ParticipantExits.p_participant_decides_if_he_wants_to_exit(
-                self.params, 0, 0, self.default_state)
+        self.params["probability_func"] = always
+        ans = ParticipantExits.p_participant_decides_if_he_wants_to_exit(
+            self.params, 0, 0, self.default_state)
 
-            self.assertEqual(len(ans["defectors"]), 4)
+        self.assertEqual(len(ans["defectors"]), 4)
 
     def test_su_remove_participants_from_network(self):
         policy_output = {

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -70,7 +70,8 @@ class CommonsSimulationConfiguration:
                  kappa=2,
                  days_to_80p_of_max_voting_weight=10,
                  max_proposal_request=0.2,
-                 timesteps_days=730):
+                 timesteps_days=730,
+                 random_state=np.random.RandomState(None)):
         self.hatchers = hatchers
         self.proposals = proposals
         self.hatch_tribute = hatch_tribute
@@ -85,6 +86,8 @@ class CommonsSimulationConfiguration:
         self.max_proposal_request = max_proposal_request
 
         self.timesteps_days = timesteps_days  # Simulate 2*365=730 days
+
+        self.random_state = random_state
 
     def __repr__(self):
         return "<{} {}>".format(self.__class__.__name__, attrs(self))
@@ -108,7 +111,7 @@ class CommonsSimulationConfiguration:
 
 
 def bootstrap_simulation(c: CommonsSimulationConfiguration):
-    contributions = [np.random.rand() * 10e5 for i in range(c.hatchers)]
+    contributions = [c.random_state.rand() * 10e5 for i in range(c.hatchers)]
     cliff_days, halflife_days = c.cliff_and_halflife()
     token_batches, initial_token_supply = create_token_batches(
         contributions, 0.1, cliff_days, halflife_days)
@@ -116,7 +119,7 @@ def bootstrap_simulation(c: CommonsSimulationConfiguration):
     commons = Commons(sum(contributions), initial_token_supply,
                       hatch_tribute=c.hatch_tribute, exit_tribute=c.exit_tribute, kappa=c.kappa)
     network = bootstrap_network(
-        token_batches, c.proposals, commons._funding_pool, commons._token_supply, c.max_proposal_request)
+        token_batches, c.proposals, commons._funding_pool, commons._token_supply, c.max_proposal_request, c.random_state)
 
     initial_conditions = {
         "network": network,
@@ -140,6 +143,7 @@ def bootstrap_simulation(c: CommonsSimulationConfiguration):
             "debug": True,
             "alpha_days_to_80p_of_max_voting_weight": c.alpha(),
             "max_proposal_request": c.max_proposal_request,
+            "random_state": c.random_state
         }
     }
 

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -1,11 +1,11 @@
 from typing import Tuple
 import numpy as np
-from scipy.stats import expon, gamma    
 from hatch import create_token_batches, TokenBatch, Commons, convert_80p_to_cliff_and_halflife
 
 from entities import attrs
 from policies import GenerateNewParticipant, GenerateNewProposal, GenerateNewFunding, ActiveProposals, ProposalFunding, ParticipantVoting, ParticipantSellsTokens, ParticipantBuysTokens, ParticipantExits
 from network_utils import bootstrap_network, calc_avg_sentiment
+from utils import new_probability_func, new_exponential_func, new_gamma_func, new_random_number_func, new_choice_func
 
 
 def update_collateral_pool(params, step, sL, s, _input):
@@ -40,43 +40,6 @@ def update_avg_sentiment(params, step, sL, s, _input):
 
 def save_policy_output(params, step, sL, s, _input):
     return "policy_output", _input
-
-
-def new_probability_func(seed):
-    random_state = np.random.RandomState(seed)
-    def probability(rate):
-        if rate > 1.0:
-            raise Exception("Rate has a maximum value of 1.0")
-        return random_state.rand() < rate
-    return probability
-
-
-def new_exponential_func(seed):
-    random_state = np.random.RandomState(seed)
-    def exponential(loc, scale):
-        return expon.rvs(loc=loc, scale=scale, random_state=random_state)
-    return exponential
-
-
-def new_gamma_func(seed):
-    random_state = np.random.RandomState(seed)
-    def gamma_func(alpha, loc, scale):
-        return gamma.rvs(alpha, loc=loc, scale=scale, random_state=random_state)
-    return gamma_func
-
-
-def new_random_number_func(seed):
-    random_state = np.random.RandomState(seed)
-    def random_number_func():
-        return random_state.rand()
-    return random_number_func
-
-
-def new_choice_func(seed):
-    random_state = np.random.RandomState(seed)
-    def choice_func(choice_list):
-        return random_state.choice(choice_list)
-    return choice_func
 
 
 # This sub-policy block should be run every time the Commons object is updated.

--- a/simulation/utils.py
+++ b/simulation/utils.py
@@ -4,15 +4,6 @@ from types import FunctionType
 from scipy.stats import expon, gamma    
 
 
-def probability(rate):
-    """
-    The higher the rate, the more likely this function will return True (up till 1.0)
-    Mock this function out to make behaviour deterministic.
-    """
-    if rate > 1.0:
-        raise Exception("Rate has a maximum value of 1.0")
-    return np.random.rand() < rate
-
 
 def new_probability_func(seed):
     random_state = np.random.RandomState(seed)

--- a/simulation/utils.py
+++ b/simulation/utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 from inspect import getmembers
 from types import FunctionType
-from scipy.stats import expon, gamma    
+from scipy.stats import expon, gamma
 
 
 

--- a/simulation/utils.py
+++ b/simulation/utils.py
@@ -3,14 +3,14 @@ from inspect import getmembers
 from types import FunctionType
 
 
-def probability(rate, random_state):
+def probability(rate):
     """
     The higher the rate, the more likely this function will return True (up till 1.0)
     Mock this function out to make behaviour deterministic.
     """
     if rate > 1.0:
         raise Exception("Rate has a maximum value of 1.0")
-    return random_state.rand() < rate
+    return np.random.rand() < rate
 
 
 """

--- a/simulation/utils.py
+++ b/simulation/utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 from inspect import getmembers
 from types import FunctionType
+from scipy.stats import expon, gamma    
 
 
 def probability(rate):
@@ -11,6 +12,43 @@ def probability(rate):
     if rate > 1.0:
         raise Exception("Rate has a maximum value of 1.0")
     return np.random.rand() < rate
+
+
+def new_probability_func(seed):
+    random_state = np.random.RandomState(seed)
+    def probability(rate):
+        if rate > 1.0:
+            raise Exception("Rate has a maximum value of 1.0")
+        return random_state.rand() < rate
+    return probability
+
+
+def new_exponential_func(seed):
+    random_state = np.random.RandomState(seed)
+    def exponential(loc, scale):
+        return expon.rvs(loc=loc, scale=scale, random_state=random_state)
+    return exponential
+
+
+def new_gamma_func(seed):
+    random_state = np.random.RandomState(seed)
+    def gamma_func(alpha, loc, scale):
+        return gamma.rvs(alpha, loc=loc, scale=scale, random_state=random_state)
+    return gamma_func
+
+
+def new_random_number_func(seed):
+    random_state = np.random.RandomState(seed)
+    def random_number_func():
+        return random_state.rand()
+    return random_number_func
+
+
+def new_choice_func(seed):
+    random_state = np.random.RandomState(seed)
+    def choice_func(choice_list):
+        return random_state.choice(choice_list)
+    return choice_func
 
 
 """

--- a/simulation/utils.py
+++ b/simulation/utils.py
@@ -3,14 +3,14 @@ from inspect import getmembers
 from types import FunctionType
 
 
-def probability(rate):
+def probability(rate, random_state):
     """
     The higher the rate, the more likely this function will return True (up till 1.0)
     Mock this function out to make behaviour deterministic.
     """
     if rate > 1.0:
         raise Exception("Rate has a maximum value of 1.0")
-    return np.random.rand() < rate
+    return random_state.rand() < rate
 
 
 """

--- a/simulation/utils_test.py
+++ b/simulation/utils_test.py
@@ -5,9 +5,31 @@ import numpy as np
 
 
 class TestUtils(unittest.TestCase):
-    def test_probability(self):
-        results = [utils.probability(0.1) for _ in range(10)]
+    def test_new_probability_func(self):
+        probability = utils.new_probability_func(seed=None) 
+        results = [probability(0.1) for _ in range(10)]
         self.assertGreater(results.count(False), results.count(True))
 
-        results2 = [utils.probability(1.0) for _ in range(2)]
+        results2 = [probability(1.0) for _ in range(2)]
         self.assertEqual(results2.count(True), 2)
+
+    def test_new_exponential_func(self):
+        exponential = utils.new_exponential_func(seed=None)
+        result = exponential(loc=0, scale=100)
+        self.assertGreater(result, 0)
+
+    def test_new_gamma_func(self):
+        gamma = utils.new_gamma_func(seed=None)
+        result = gamma(3, loc=0.001, scale=10000)
+        self.assertGreater(result, 1000)
+    
+    def test_new_random_number_func(self):
+        random_number = utils.new_random_number_func(seed=None)
+        result = random_number()
+        self.assertTrue(result >= 0 and result <= 1)
+
+    def test_choice_function(self):
+        choice = utils.new_choice_func(seed=None)
+        count_list = list(range(10))
+        result = choice(count_list)
+        self.assertTrue(result in count_list)

--- a/simulation/utils_test.py
+++ b/simulation/utils_test.py
@@ -5,15 +5,9 @@ import numpy as np
 
 
 class TestUtils(unittest.TestCase):
-    def setUp(self):
-        self.params = {"random_state": np.random.RandomState(None)}
-
     def test_probability(self):
-        results = [utils.probability(0.1, self.params["random_state"]) for _ in range(10)]
+        results = [utils.probability(0.1) for _ in range(10)]
         self.assertGreater(results.count(False), results.count(True))
 
-        results2 = [utils.probability(1.0, self.params["random_state"]) for _ in range(2)]
+        results2 = [utils.probability(1.0) for _ in range(2)]
         self.assertEqual(results2.count(True), 2)
-
-if __name__ == "__main__":
-    unittest.main()

--- a/simulation/utils_test.py
+++ b/simulation/utils_test.py
@@ -6,30 +6,30 @@ import numpy as np
 
 class TestUtils(unittest.TestCase):
     def test_new_probability_func(self):
-        probability = utils.new_probability_func(seed=None) 
-        results = [probability(0.1) for _ in range(10)]
+        probability_func = utils.new_probability_func(seed=None)
+        results = [probability_func(0.1) for _ in range(10)]
         self.assertGreater(results.count(False), results.count(True))
 
-        results2 = [probability(1.0) for _ in range(2)]
+        results2 = [probability_func(1.0) for _ in range(2)]
         self.assertEqual(results2.count(True), 2)
 
     def test_new_exponential_func(self):
-        exponential = utils.new_exponential_func(seed=None)
-        result = exponential(loc=0, scale=100)
+        exponential_func = utils.new_exponential_func(seed=None)
+        result = exponential_func(loc=0, scale=100)
         self.assertGreater(result, 0)
 
     def test_new_gamma_func(self):
-        gamma = utils.new_gamma_func(seed=None)
-        result = gamma(3, loc=0.001, scale=10000)
+        gamma_func = utils.new_gamma_func(seed=None)
+        result = gamma_func(3, loc=0.001, scale=10000)
         self.assertGreater(result, 1000)
-    
+
     def test_new_random_number_func(self):
-        random_number = utils.new_random_number_func(seed=None)
-        result = random_number()
+        random_number_func = utils.new_random_number_func(seed=None)
+        result = random_number_func()
         self.assertTrue(result >= 0 and result <= 1)
 
     def test_choice_function(self):
-        choice = utils.new_choice_func(seed=None)
+        choice_func = utils.new_choice_func(seed=None)
         count_list = list(range(10))
-        result = choice(count_list)
+        result = choice_func(count_list)
         self.assertTrue(result in count_list)

--- a/simulation/utils_test.py
+++ b/simulation/utils_test.py
@@ -1,12 +1,19 @@
 import unittest
 import networkx as nx
 import utils
+import numpy as np
 
 
 class TestUtils(unittest.TestCase):
+    def setUp(self):
+        self.params = {"random_state": np.random.RandomState(None)}
+
     def test_probability(self):
-        results = [utils.probability(0.1) for _ in range(10)]
+        results = [utils.probability(0.1, self.params["random_state"]) for _ in range(10)]
         self.assertGreater(results.count(False), results.count(True))
 
-        results2 = [utils.probability(1.0) for _ in range(2)]
+        results2 = [utils.probability(1.0, self.params["random_state"]) for _ in range(2)]
         self.assertEqual(results2.count(True), 2)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a random state parameter in simulation configs, so it is possible to toggle between random and deterministic results just by changing the Numpy's random state seed (None for random results or int for deterministic results) in `simulation.py`.

The random_state was passed through the entities, utils, and network utils by the policies as a non-optionalinput, so several unit tests had to be changed to expect a random state.