### PR TITLE
Fix su_update_sentiment when status proposal fail or complete

### DIFF
--- a/simulation/policies_test.py
+++ b/simulation/policies_test.py
@@ -17,6 +17,8 @@ from policies import (ActiveProposals, GenerateNewFunding,
                       ParticipantSellsTokens, ParticipantVoting,
                       ProposalFunding)
 
+import config
+
 
 class TestGenerateNewParticipant(unittest.TestCase):
     def setUp(self):
@@ -578,15 +580,21 @@ class TestParticipantExits(unittest.TestCase):
             "succeeded": [5]
         }
 
-        # Let's say Participant 2 owns Proposal 4, Participant 3 owns Proposal 5
-        self.network.nodes[2]["item"].sentiment = 0.5
-        self.network.nodes[3]["item"].sentiment = 0.7
+        # Let's say Participant 2 owns Proposal 4, Participant 3 owns Proposal 5 and have staked on Proposal 4
+        participant_2_sentiment = 0.5
+        participant_3_sentiment = 0.7
+        self.network.nodes[2]["item"].sentiment = participant_2_sentiment
+        self.network.nodes[3]["item"].sentiment = participant_3_sentiment
         self.network.edges[2, 4]["affinity"] = 1
+        self.network.edges[3, 4]["tokens"] = 1
+        self.network.edges[2, 5]["tokens"] = 0
         self.network.edges[3, 5]["affinity"] = 1
 
         self.default_state["policy_output"] = policy_output_passthru
         _, n_network = ParticipantExits.su_update_sentiment_when_proposal_becomes_failed_or_completed(
             self.params, 0, 0, self.default_state, {})
 
-        self.assertEqual(n_network.nodes[2]["item"].sentiment, 0.4)
-        self.assertEqual(n_network.nodes[3]["item"].sentiment, 1)
+        new_sentiment_2 = (participant_2_sentiment + 1 * config.sentiment_bonus_proposal_becomes_failed)
+        new_sentiment_3 = (participant_3_sentiment + (self.network.edges[3, 4]["affinity"] * config.sentiment_bonus_proposal_becomes_failed)) + (1 * config.sentiment_bonus_proposal_becomes_completed)
+        self.assertEqual(n_network.nodes[2]["item"].sentiment, new_sentiment_2)
+        self.assertEqual(n_network.nodes[3]["item"].sentiment, new_sentiment_3)


### PR DESCRIPTION
This PR introduces some changes to the `ParticipantExits.su_update_sentiment_when_proposal_becomes_failed_or_completed` state update function so when a proposal fails/completes, the sentiment is updated for both the owner and all participants who staked on that proposal, and proportionally to the affinity they had for it.

This new behaviour makes the average sentiment to be more sensitive on how proposals evolve through the simulation and also introduces more pressure on selling tokens, so its price fluctuates instead of having a constantly increasing price trend.