### PR TITLE
Create integration test file and add test for token batch update age

### DIFF
--- a/simulation/entities.py
+++ b/simulation/entities.py
@@ -215,3 +215,10 @@ class Participant:
             engagement_rate = 0.3 * self.sentiment
             return self._probability_func(1-engagement_rate)
         return False
+
+    def update_token_batch_age(self):
+        """
+        Participant.update_token_batch_age() is simply a front to
+        TokenBatch.update_age().
+        """
+        return self.holdings.update_age()

--- a/simulation/entities_test.py
+++ b/simulation/entities_test.py
@@ -153,6 +153,15 @@ class TestParticipant(unittest.TestCase):
         }
         self.assertEqual(ans, reference)
 
+    def test_update_token_batch_age(self):
+        """
+        Test that the participant token batch is updated by 1 day after
+        running Participant.update_token_batch_age()
+        """
+        old_age_days = self.p.holdings.age_days
+        new_age_days = self.p.update_token_batch_age()
+        self.assertEqual(new_age_days, old_age_days + 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/simulation/integration_test.py
+++ b/simulation/integration_test.py
@@ -15,14 +15,7 @@ from simulation import (CommonsSimulationConfiguration,
                         partial_state_update_blocks)
 
 
-def bootstrap_simulation(c: CommonsSimulationConfiguration):
-    random_seed = 1
-    probability_func = new_probability_func(random_seed)
-    exponential_func = new_exponential_func(random_seed)
-    gamma_func = new_gamma_func(random_seed)
-    random_number_func = new_random_number_func(random_seed)
-    choice_func = new_choice_func(random_seed)
-
+def bootstrap_simulation(c: CommonsSimulationConfiguration(random_seed=1)):
     contributions = [c.random_number_func() * 10e5 for i in range(c.hatchers)]
     cliff_days, halflife_days = c.cliff_and_halflife()
     token_batches, initial_token_supply = create_token_batches(
@@ -58,19 +51,19 @@ def bootstrap_simulation(c: CommonsSimulationConfiguration):
             "debug": False,
             "alpha_days_to_80p_of_max_voting_weight": c.alpha(),
             "max_proposal_request": c.max_proposal_request,
-            "random_seed": random_seed,
-            "probability_func": probability_func,
-            "exponential_func": exponential_func,
-            "gamma_func": gamma_func,
-            "random_number_func": random_number_func,
-            "choice_func": choice_func
+            "random_seed": c.random_seed,
+            "probability_func": c.probability_func,
+            "exponential_func": c.exponential_func,
+            "gamma_func": c.gamma_func,
+            "random_number_func": c.random_number_func,
+            "choice_func": c.choice_func
         }
     }
 
     return initial_conditions, simulation_parameters
 
 
-def run_simulation(c: CommonsSimulationConfiguration):
+def run_simulation(c: CommonsSimulationConfiguration(random_seed=1)):
     initial_conditions, simulation_parameters = bootstrap_simulation(c)
 
     exp = Experiment()
@@ -101,7 +94,7 @@ def run_simulation(c: CommonsSimulationConfiguration):
 
 class TestParticipant(unittest.TestCase):
     def setUp(self):
-        c = CommonsSimulationConfiguration()
+        c = CommonsSimulationConfiguration(random_seed=1)
         results, df_final = run_simulation(c)
         self.df_final = df_final
 

--- a/simulation/integration_test.py
+++ b/simulation/integration_test.py
@@ -1,0 +1,125 @@
+import pandas as pd
+from cadCAD.configuration import Experiment
+from cadCAD.configuration.utils import config_sim
+from cadCAD.engine import ExecutionContext, ExecutionMode, Executor
+from cadCAD import configs
+
+import unittest
+import numpy as np
+
+from utils import (new_probability_func, new_exponential_func, new_gamma_func,
+                   new_random_number_func, new_choice_func)
+from hatch import create_token_batches, Commons
+from network_utils import bootstrap_network, get_participants
+from simulation import (CommonsSimulationConfiguration,
+                        partial_state_update_blocks)
+
+
+def bootstrap_simulation(c: CommonsSimulationConfiguration):
+    random_seed = 1
+    probability_func = new_probability_func(random_seed)
+    exponential_func = new_exponential_func(random_seed)
+    gamma_func = new_gamma_func(random_seed)
+    random_number_func = new_random_number_func(random_seed)
+    choice_func = new_choice_func(random_seed)
+
+    contributions = [c.random_number_func() * 10e5 for i in range(c.hatchers)]
+    cliff_days, halflife_days = c.cliff_and_halflife()
+    token_batches, initial_token_supply = create_token_batches(
+        contributions, 0.1, cliff_days, halflife_days)
+
+    commons = Commons(sum(contributions), initial_token_supply,
+                      hatch_tribute=c.hatch_tribute,
+                      exit_tribute=c.exit_tribute, kappa=c.kappa)
+    network = bootstrap_network(
+        token_batches, c.proposals, commons._funding_pool,
+        commons._token_supply, c.max_proposal_request, c.probability_func,
+        c.random_number_func, c.gamma_func, c.exponential_func)
+
+    initial_conditions = {
+        "network": network,
+        "commons": commons,
+        "funding_pool": commons._funding_pool,
+        "collateral_pool": commons._collateral_pool,
+        "token_supply": commons._token_supply,
+        "token_price": commons.token_price(),
+        "policy_output": None,
+        "sentiment": 0.5
+    }
+
+    simulation_parameters = {
+        'T': range(c.timesteps_days),
+        'N': 1,
+        'M': {
+            # "sentiment_decay": 0.01, #termed mu in the state update function
+            # "min_proposal_age_days": 7, # minimum periods passed before a proposal can pass,
+            # "sentiment_sensitivity": 0.75,
+            # 'min_supp':50, #number of tokens that must be stake for a proposal to be a candidate
+            "debug": False,
+            "alpha_days_to_80p_of_max_voting_weight": c.alpha(),
+            "max_proposal_request": c.max_proposal_request,
+            "random_seed": random_seed,
+            "probability_func": probability_func,
+            "exponential_func": exponential_func,
+            "gamma_func": gamma_func,
+            "random_number_func": random_number_func,
+            "choice_func": choice_func
+        }
+    }
+
+    return initial_conditions, simulation_parameters
+
+
+def run_simulation(c: CommonsSimulationConfiguration):
+    initial_conditions, simulation_parameters = bootstrap_simulation(c)
+
+    exp = Experiment()
+    exp.append_configs(
+        initial_state=initial_conditions,
+        partial_state_update_blocks=partial_state_update_blocks,
+        sim_configs=simulation_parameters
+    )
+
+    # Do not use multi_proc, breaks ipdb.set_trace()
+    exec_mode = ExecutionMode()
+    single_proc_context = ExecutionContext(exec_mode.local_mode)
+    executor = Executor(single_proc_context, configs)
+
+    raw_system_events, tensor_field, sessions = executor.execute()
+
+    df = pd.DataFrame(raw_system_events)
+    df_final = df[df.substep.eq(2)]
+
+    result = {
+        "timestep": list(df_final["timestep"]),
+        "funding_pool": list(df_final["funding_pool"]),
+        "token_price": list(df_final["token_price"]),
+        "sentiment": list(df_final["sentiment"])
+    }
+    return result, df_final
+
+
+class TestParticipant(unittest.TestCase):
+    def setUp(self):
+        c = CommonsSimulationConfiguration()
+        results, df_final = run_simulation(c)
+        self.df_final = df_final
+
+    def test_participant_token_batch_age_is_updated_every_timestep(self):
+        """
+        Test that the age of the Participants' token batch is updated every
+        timestep. The test checks if the older token batch age has the same age
+        of the simulation (timestep). It considers that at least one
+        participant stays in the commons from the beginning to the end of the
+        simulation.
+        """
+        for index, row in self.df_final.iterrows():
+            timestep = row['timestep']
+            network = row['network']
+            participants = get_participants(network)
+
+        participants_token_batch_ages = []
+        for i, participant in participants:
+            participants_token_batch_ages.append(participant.holdings.age_days)
+        # Check if the older token batch has the same age of the simulation
+        self.assertEqual(max(participants_token_batch_ages), timestep)

--- a/simulation/integration_test.py
+++ b/simulation/integration_test.py
@@ -11,85 +11,9 @@ from utils import (new_probability_func, new_exponential_func, new_gamma_func,
                    new_random_number_func, new_choice_func)
 from hatch import create_token_batches, Commons
 from network_utils import bootstrap_network, get_participants
-from simulation import (CommonsSimulationConfiguration,
+from simrunner import run_simulation
+from simulation import (bootstrap_simulation, CommonsSimulationConfiguration,
                         partial_state_update_blocks)
-
-
-def bootstrap_simulation(c: CommonsSimulationConfiguration(random_seed=1)):
-    contributions = [c.random_number_func() * 10e5 for i in range(c.hatchers)]
-    cliff_days, halflife_days = c.cliff_and_halflife()
-    token_batches, initial_token_supply = create_token_batches(
-        contributions, 0.1, cliff_days, halflife_days)
-
-    commons = Commons(sum(contributions), initial_token_supply,
-                      hatch_tribute=c.hatch_tribute,
-                      exit_tribute=c.exit_tribute, kappa=c.kappa)
-    network = bootstrap_network(
-        token_batches, c.proposals, commons._funding_pool,
-        commons._token_supply, c.max_proposal_request, c.probability_func,
-        c.random_number_func, c.gamma_func, c.exponential_func)
-
-    initial_conditions = {
-        "network": network,
-        "commons": commons,
-        "funding_pool": commons._funding_pool,
-        "collateral_pool": commons._collateral_pool,
-        "token_supply": commons._token_supply,
-        "token_price": commons.token_price(),
-        "policy_output": None,
-        "sentiment": 0.5
-    }
-
-    simulation_parameters = {
-        'T': range(c.timesteps_days),
-        'N': 1,
-        'M': {
-            # "sentiment_decay": 0.01, #termed mu in the state update function
-            # "min_proposal_age_days": 7, # minimum periods passed before a proposal can pass,
-            # "sentiment_sensitivity": 0.75,
-            # 'min_supp':50, #number of tokens that must be stake for a proposal to be a candidate
-            "debug": False,
-            "alpha_days_to_80p_of_max_voting_weight": c.alpha(),
-            "max_proposal_request": c.max_proposal_request,
-            "random_seed": c.random_seed,
-            "probability_func": c.probability_func,
-            "exponential_func": c.exponential_func,
-            "gamma_func": c.gamma_func,
-            "random_number_func": c.random_number_func,
-            "choice_func": c.choice_func
-        }
-    }
-
-    return initial_conditions, simulation_parameters
-
-
-def run_simulation(c: CommonsSimulationConfiguration(random_seed=1)):
-    initial_conditions, simulation_parameters = bootstrap_simulation(c)
-
-    exp = Experiment()
-    exp.append_configs(
-        initial_state=initial_conditions,
-        partial_state_update_blocks=partial_state_update_blocks,
-        sim_configs=simulation_parameters
-    )
-
-    # Do not use multi_proc, breaks ipdb.set_trace()
-    exec_mode = ExecutionMode()
-    single_proc_context = ExecutionContext(exec_mode.local_mode)
-    executor = Executor(single_proc_context, configs)
-
-    raw_system_events, tensor_field, sessions = executor.execute()
-
-    df = pd.DataFrame(raw_system_events)
-    df_final = df[df.substep.eq(2)]
-
-    result = {
-        "timestep": list(df_final["timestep"]),
-        "funding_pool": list(df_final["funding_pool"]),
-        "token_price": list(df_final["token_price"]),
-        "sentiment": list(df_final["sentiment"])
-    }
-    return result, df_final
 
 
 class TestParticipant(unittest.TestCase):

--- a/simulation/integration_test.py
+++ b/simulation/integration_test.py
@@ -11,7 +11,7 @@ from utils import (new_probability_func, new_exponential_func, new_gamma_func,
                    new_random_number_func, new_choice_func)
 from hatch import create_token_batches, Commons
 from network_utils import bootstrap_network, get_participants
-from simrunner import run_simulation
+from simrunner import get_simulation_results
 from simulation import (bootstrap_simulation, CommonsSimulationConfiguration,
                         partial_state_update_blocks)
 
@@ -19,7 +19,7 @@ from simulation import (bootstrap_simulation, CommonsSimulationConfiguration,
 class TestParticipant(unittest.TestCase):
     def setUp(self):
         c = CommonsSimulationConfiguration(random_seed=1)
-        results, df_final = run_simulation(c)
+        results, df_final = get_simulation_results(c)
         self.df_final = df_final
 
     def test_participant_token_batch_age_is_updated_every_timestep(self):
@@ -35,8 +35,8 @@ class TestParticipant(unittest.TestCase):
             network = row['network']
             participants = get_participants(network)
 
-        participants_token_batch_ages = []
-        for i, participant in participants:
-            participants_token_batch_ages.append(participant.holdings.age_days)
-        # Check if the older token batch has the same age of the simulation
-        self.assertEqual(max(participants_token_batch_ages), timestep)
+            participants_token_batch_ages = []
+            for i, participant in participants:
+                participants_token_batch_ages.append(participant.holdings.age_days)
+            # Check if the older token batch has the same age of the simulation
+            self.assertEqual(max(participants_token_batch_ages), timestep)

--- a/simulation/policies.py
+++ b/simulation/policies.py
@@ -68,6 +68,15 @@ class GenerateNewParticipant:
                 _input["new_participant_investment"])
         return "commons", commons
 
+    @staticmethod
+    def su_update_participants_token_batch_age(params, step, sL, s, _input, **kwargs):
+        network = s["network"]
+        participants = get_participants(network)
+        for i, participant in participants:
+            participant.update_token_batch_age()
+
+        return "network", network
+
 
 class GenerateNewProposal:
     @staticmethod

--- a/simulation/policies_test.py
+++ b/simulation/policies_test.py
@@ -90,6 +90,18 @@ class TestGenerateNewParticipant(unittest.TestCase):
             for u, v in network.in_edges(5):
                 self.assertEqual(network.edges[u, v]["type"], "influence")
 
+    def test_su_update_participants_token_batch_age(self):
+        """
+        Test that after running the state update function the participants'
+        token batch age in days are incremented by one
+        """
+        _input = {}
+        _, network = GenerateNewParticipant.su_update_participants_token_batch_age(
+                self.params, 0, 0, {"network": self.network.copy()}, _input)
+        participants = get_participants(network)
+        for i, participant in participants:
+            self.assertEqual(participant.holdings.age_days, 1)
+
 
 class TestGenerateNewProposal(unittest.TestCase):
     def setUp(self):

--- a/simulation/simrunner.py
+++ b/simulation/simrunner.py
@@ -43,26 +43,27 @@ def run_simulation(c: CommonsSimulationConfiguration):
     return result, df_final
 
 
-parser = argparse.ArgumentParser()
-c_default = CommonsSimulationConfiguration()
-parser.add_argument("--hatchers", type=int, default=c_default.hatchers)
-parser.add_argument("--proposals", type=int, default=c_default.proposals)
-parser.add_argument("--hatch_tribute", type=float,
-                    default=c_default.hatch_tribute)
-parser.add_argument("--vesting_80p_unlocked", type=float,
-                    default=c_default.vesting_80p_unlocked)
-parser.add_argument("--exit_tribute", type=float,
-                    default=c_default.exit_tribute)
-parser.add_argument("--kappa", type=int, default=c_default.kappa)
-parser.add_argument("--days_to_80p_of_max_voting_weight",
-                    type=int, default=c_default.days_to_80p_of_max_voting_weight)
-parser.add_argument("--max_proposal_request", type=float,
-                    default=c_default.max_proposal_request)
-parser.add_argument("-T", "--timesteps_days", type=int,
-                    default=c_default.timesteps_days)
-args = parser.parse_args()
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    c_default = CommonsSimulationConfiguration()
+    parser.add_argument("--hatchers", type=int, default=c_default.hatchers)
+    parser.add_argument("--proposals", type=int, default=c_default.proposals)
+    parser.add_argument("--hatch_tribute", type=float,
+                        default=c_default.hatch_tribute)
+    parser.add_argument("--vesting_80p_unlocked", type=float,
+                        default=c_default.vesting_80p_unlocked)
+    parser.add_argument("--exit_tribute", type=float,
+                        default=c_default.exit_tribute)
+    parser.add_argument("--kappa", type=int, default=c_default.kappa)
+    parser.add_argument("--days_to_80p_of_max_voting_weight",
+                        type=int, default=c_default.days_to_80p_of_max_voting_weight)
+    parser.add_argument("--max_proposal_request", type=float,
+                        default=c_default.max_proposal_request)
+    parser.add_argument("-T", "--timesteps_days", type=int,
+                        default=c_default.timesteps_days)
+    args = parser.parse_args()
 
-c = CommonsSimulationConfiguration(**vars(args))
-print("Running sim config", c)
-o, _ = run_simulation(c)
-print(json.dumps(o))
+    c = CommonsSimulationConfiguration(**vars(args))
+    print("Running sim config", c)
+    o, _ = run_simulation(c)
+    print(json.dumps(o))

--- a/simulation/simrunner.py
+++ b/simulation/simrunner.py
@@ -32,6 +32,11 @@ def run_simulation(c: CommonsSimulationConfiguration):
     raw_system_events, tensor_field, sessions = executor.execute()
 
     df = pd.DataFrame(raw_system_events)
+    return df
+
+
+def get_simulation_results(c):
+    df = run_simulation(c)
     df_final = df[df.substep.eq(2)]
 
     result = {
@@ -65,5 +70,5 @@ if __name__ == "__main__":
 
     c = CommonsSimulationConfiguration(**vars(args))
     print("Running sim config", c)
-    o, _ = run_simulation(c)
+    o, _ = get_simulation_results(c)
     print(json.dumps(o))

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -172,6 +172,12 @@ partial_state_update_blocks = [
             'commons': GenerateNewParticipant.su_add_investment_to_commons,
         }
     },
+    {
+        "policies": {},
+        "variables": {
+            "network": GenerateNewParticipant.su_update_participants_token_batch_age,
+        }
+    },
     sync_state_variables,
     {
         "policies": {

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -101,9 +101,9 @@ class CommonsSimulationConfiguration:
     def alpha(self) -> float:
         """
         Converts days_to_80p_of_max_voting_weight to alpha.
-        alpha = 0.8 ^ (1/t)
+        alpha = (1 - 0.8) ^ (1/t)
         """
-        return 0.8 ** (1/self.days_to_80p_of_max_voting_weight)
+        return 0.2 ** (1/self.days_to_80p_of_max_voting_weight)
 
     def cliff_and_halflife(self) -> Tuple[float, float]:
         """


### PR DESCRIPTION
This PR creates a file `integration_test.py`, where there will be more integration tests in the future. The integration tests use a defined random seed to assure repeatable results every run. In this case, a seed == 1 was arbitrarily defined. It adds a test to assure that the Participants' TokenBatch ages are being updated every timestep.

Refs #46 