### PR TITLE
Fix alpha derivation formula

### DIFF
--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -101,9 +101,9 @@ class CommonsSimulationConfiguration:
     def alpha(self) -> float:
         """
         Converts days_to_80p_of_max_voting_weight to alpha.
-        alpha = 0.8 ^ (1/t)
+        alpha = (1 - 0.8) ^ (1/t)
         """
-        return 0.8 ** (1/self.days_to_80p_of_max_voting_weight)
+        return 0.2 ** (1/self.days_to_80p_of_max_voting_weight)
 
     def cliff_and_halflife(self) -> Tuple[float, float]:
         """


### PR DESCRIPTION
In order to derive alpha from the time needed to reach 80% conviction we need to use the formula:

```python
alpha = (1 - 0.8) ** (1 / t)
```

I have prepared this [demo](https://www.desmos.com/calculator/hs7qsnk5zg) for better understanding.