### PR TITLE
Marthendalnunes/integration test update conviction

### DIFF
--- a/simulation/integration_test.py
+++ b/simulation/integration_test.py
@@ -6,14 +6,45 @@ from cadCAD import configs
 
 import unittest
 import numpy as np
+import copy
 
 from utils import (new_probability_func, new_exponential_func, new_gamma_func,
                    new_random_number_func, new_choice_func)
 from hatch import create_token_batches, Commons
-from network_utils import bootstrap_network, get_participants
 from simrunner import get_simulation_results
+from network_utils import (bootstrap_network, get_participants,
+                           get_edges_by_type)
 from simulation import (bootstrap_simulation, CommonsSimulationConfiguration,
                         partial_state_update_blocks)
+
+
+def run_simulation(c: CommonsSimulationConfiguration):
+    initial_conditions, simulation_parameters = bootstrap_simulation(c)
+
+    exp = Experiment()
+    exp.append_configs(
+        initial_state=initial_conditions,
+        partial_state_update_blocks=partial_state_update_blocks,
+        sim_configs=simulation_parameters
+    )
+
+    # Do not use multi_proc, breaks ipdb.set_trace()
+    exec_mode = ExecutionMode()
+    single_proc_context = ExecutionContext(exec_mode.local_mode)
+    executor = Executor(single_proc_context, configs)
+
+    raw_system_events, tensor_field, sessions = executor.execute()
+
+    df = pd.DataFrame(raw_system_events)
+    df_final = df
+
+    result = {
+        "timestep": list(df_final["timestep"]),
+        "funding_pool": list(df_final["funding_pool"]),
+        "token_price": list(df_final["token_price"]),
+        "sentiment": list(df_final["sentiment"])
+    }
+    return result, df_final
 
 
 class TestParticipant(unittest.TestCase):
@@ -21,22 +52,62 @@ class TestParticipant(unittest.TestCase):
         c = CommonsSimulationConfiguration(random_seed=1)
         results, df_final = get_simulation_results(c)
         self.df_final = df_final
+        PSUBs_labels = {}
+        for idx, block in enumerate(partial_state_update_blocks):
+            PSUBs_labels[idx+1] = block["label"]
+
+        self.PSUBs_labels = PSUBs_labels
 
     def test_participant_token_batch_age_is_updated_every_timestep(self):
-        """
-        Test that the age of the Participants' token batch is updated every
-        timestep. The test checks if the older token batch age has the same age
-        of the simulation (timestep). It considers that at least one
-        participant stays in the commons from the beginning to the end of the
-        simulation.
-        """
-        for index, row in self.df_final.iterrows():
-            timestep = row['timestep']
-            network = row['network']
-            participants = get_participants(network)
+            """
+            Test that the age of the Participants' token batch is updated every
+            timestep. The test checks if the older token batch age has the same
+            age
+            of the simulation (timestep). It considers that at least one
+            participant stays in the commons from the beginning to the end of the
+            simulation.
+            """
+            for index, row in self.df_final.iterrows():
+                timestep = row["timestep"]
+                network = row["network"]
+                participants = get_participants(network)
 
             participants_token_batch_ages = []
             for i, participant in participants:
                 participants_token_batch_ages.append(participant.holdings.age_days)
             # Check if the older token batch has the same age of the simulation
             self.assertEqual(max(participants_token_batch_ages), timestep)
+
+    def test_conviction_is_updated_once_by_timestep(self):
+        for index, row in self.df_final.iterrows():
+            timestep = row["timestep"]
+            substep = row["substep"]
+            network = row["network"]
+            # Arbitrarily testing timestep 2
+            if timestep == 2:
+                print("substep", substep)
+                support_edges = get_edges_by_type(network, "support")
+                conviction_list = []
+                for i, j in support_edges:
+                    edge = network.edges[i, j]
+                    prior_conviction = edge["conviction"]
+                    conviction_list.append(prior_conviction)
+                # If there is no timestep before, there is no need (later test
+                # this with the last substep of the last timestep)
+                if substep > 1:
+                    if self.PSUBs_labels[substep] == "Generate new proposals":
+                        length_diff = len(conviction_list) - len(prior_conviction_list)
+                        priot_conviction_list = prior_conviction_list + [0.0] * length_diff
+                        self.assertEqual(conviction_list, priot_conviction_list)
+                        prior_conviction_list = copy.deepcopy(conviction_list)
+
+                    if self.PSUBs_labels[substep] == "Calculate proposals' conviction":
+                        # Checks that no proposal have been added or removed
+                        self.assertEqual(len(conviction_list), len(prior_conviction_list))
+                        self.assertFalse(conviction_list == prior_conviction_list)
+
+                    else:
+                        self.assertEqual(conviction_list, prior_conviction_list)
+
+                    prior_conviction_list = copy.deepcopy(conviction_list)
+                prior_conviction_list = copy.deepcopy(conviction_list)

--- a/simulation/integration_test.py
+++ b/simulation/integration_test.py
@@ -24,10 +24,6 @@ class TestParticipant(unittest.TestCase):
         results, df_final = get_simulation_results(c)
         self.df_final = df_final
 
-<<<<<<< HEAD
-
-=======
->>>>>>>  Add int test to ensure conviction is updated only once
     def test_participant_token_batch_age_is_updated_every_timestep(self):
         """
         Test that the age of the Participants' token batch is updated every

--- a/simulation/integration_test.py
+++ b/simulation/integration_test.py
@@ -11,9 +11,9 @@ import copy
 from utils import (new_probability_func, new_exponential_func, new_gamma_func,
                    new_random_number_func, new_choice_func)
 from hatch import create_token_batches, Commons
-from simrunner import get_simulation_results
+from simrunner import get_simulation_results, run_simulation
 from network_utils import (bootstrap_network, get_participants,
-                           get_edges_by_type)
+                           get_edges_by_type, get_proposals_conviction_list)
 from simulation import (bootstrap_simulation, CommonsSimulationConfiguration,
                         partial_state_update_blocks)
 
@@ -24,26 +24,30 @@ class TestParticipant(unittest.TestCase):
         results, df_final = get_simulation_results(c)
         self.df_final = df_final
 
+<<<<<<< HEAD
 
+=======
+>>>>>>>  Add int test to ensure conviction is updated only once
     def test_participant_token_batch_age_is_updated_every_timestep(self):
-            """
-            Test that the age of the Participants' token batch is updated every
-            timestep. The test checks if the older token batch age has the same
-            age
-            of the simulation (timestep). It considers that at least one
-            participant stays in the commons from the beginning to the end of the
-            simulation.
-            """
-            for index, row in self.df_final.iterrows():
-                timestep = row["timestep"]
-                network = row["network"]
-                participants = get_participants(network)
+        """
+        Test that the age of the Participants' token batch is updated every
+        timestep. The test checks if the older token batch age has the same
+        age
+        of the simulation (timestep). It considers that at least one
+        participant stays in the commons from the beginning to the end of the
+        simulation.
+        """
+        for index, row in self.df_final.iterrows():
+            timestep = row["timestep"]
+            network = row["network"]
+            participants = get_participants(network)
 
-                participants_token_batch_ages = []
-                for i, participant in participants:
-                    participants_token_batch_ages.append(participant.holdings.age_days)
-                # Check if the older token batch has the same age of the simulation
-                self.assertEqual(max(participants_token_batch_ages), timestep)
+            participants_token_batch_ages = []
+            for i, participant in participants:
+                participants_token_batch_ages.append(
+                                            participant.holdings.age_days)
+            # Check if the older token batch has the same age of the simulation
+            self.assertEqual(max(participants_token_batch_ages), timestep)
 
 
 class TestProposal(unittest.TestCase):
@@ -51,37 +55,57 @@ class TestProposal(unittest.TestCase):
         c = CommonsSimulationConfiguration(random_seed=1)
         df = run_simulation(c)
         self.df = df
-        
+
     def test_conviction_is_updated_once_by_timestep(self):
-        for index, row in self.df_final.iterrows():
+        """
+        Test that the Proposals' conviction is updated only once by timestep.
+        First it creates a new column on the result Data Frame with the psub
+        labels, and then check the behaviour of each psub. Only the psub
+        "Calculate proposals' conviction" updated the proposals' convictions.
+        The psubs "Generate new participants" and "Generate new proposals" add
+        new participants and proposals to the network, but should not affect
+        the conviction of existing proposals. The psub
+        "Participant decides if he wants to exit" removes participants from
+        the network, thus it might remove proposals created by the removed
+        participants. This psub should not affect the remainig proposals'
+        conviction. The other psubs should not affect the proposals'
+        conviction.
+
+        Reminder: Currently on the code the proposals that become active,
+        failed or completed are still having their convictions calculated.
+        """
+        psubs = partial_state_update_blocks
+        # Mapping the substep order to the PSUB label
+        psub_map = {order+1: psub['label'] for (order,
+                                                psub) in enumerate(psubs)}
+
+        # Add a column with the psub executed on each sustep
+        self.df['psubs'] = self.df.substep.map(psub_map)
+
+        for index, row in self.df.iterrows():
             timestep = row["timestep"]
-            substep = row["substep"]
+            psub = row["psubs"]
             network = row["network"]
-            # Arbitrarily testing timestep 2
-            if timestep == 2:
-                print("substep", substep)
-                support_edges = get_edges_by_type(network, "support")
-                conviction_list = []
-                for i, j in support_edges:
-                    edge = network.edges[i, j]
-                    prior_conviction = edge["conviction"]
-                    conviction_list.append(prior_conviction)
-                # If there is no timestep before, there is no need (later test
-                # this with the last substep of the last timestep)
-                if substep > 1:
-                    if self.PSUBs_labels[substep] == "Generate new proposals":
-                        length_diff = len(conviction_list) - len(prior_conviction_list)
-                        priot_conviction_list = prior_conviction_list + [0.0] * length_diff
-                        self.assertEqual(conviction_list, priot_conviction_list)
-                        prior_conviction_list = copy.deepcopy(conviction_list)
 
-                    if self.PSUBs_labels[substep] == "Calculate proposals' conviction":
-                        # Checks that no proposal have been added or removed
-                        self.assertEqual(len(conviction_list), len(prior_conviction_list))
-                        self.assertFalse(conviction_list == prior_conviction_list)
+            conviction_list = get_proposals_conviction_list(network)
 
-                    else:
-                        self.assertEqual(conviction_list, prior_conviction_list)
-
-                    prior_conviction_list = copy.deepcopy(conviction_list)
+            if timestep == 0:
                 prior_conviction_list = copy.deepcopy(conviction_list)
+            if (psub == "Generate new participants" or
+                    psub == "Generate new proposals"):
+                len_diff = len(conviction_list) - len(prior_conviction_list)
+                prior_conviction_list = prior_conviction_list + [0] * len_diff
+                self.assertEqual(sorted(conviction_list),
+                                 sorted(prior_conviction_list))
+            elif psub == "Calculate proposals' conviction":
+                # Checks that no proposal have been added or removed
+                self.assertEqual(len(conviction_list),
+                                 len(prior_conviction_list))
+                self.assertFalse(conviction_list == prior_conviction_list)
+            elif psub == "Participant decides if he wants to exit":
+                self.assertTrue(set(conviction_list) <=
+                                set(prior_conviction_list))
+            else:
+                self.assertEqual(conviction_list, prior_conviction_list)
+
+            prior_conviction_list = copy.deepcopy(conviction_list)

--- a/simulation/integration_test.py
+++ b/simulation/integration_test.py
@@ -18,45 +18,12 @@ from simulation import (bootstrap_simulation, CommonsSimulationConfiguration,
                         partial_state_update_blocks)
 
 
-def run_simulation(c: CommonsSimulationConfiguration):
-    initial_conditions, simulation_parameters = bootstrap_simulation(c)
-
-    exp = Experiment()
-    exp.append_configs(
-        initial_state=initial_conditions,
-        partial_state_update_blocks=partial_state_update_blocks,
-        sim_configs=simulation_parameters
-    )
-
-    # Do not use multi_proc, breaks ipdb.set_trace()
-    exec_mode = ExecutionMode()
-    single_proc_context = ExecutionContext(exec_mode.local_mode)
-    executor = Executor(single_proc_context, configs)
-
-    raw_system_events, tensor_field, sessions = executor.execute()
-
-    df = pd.DataFrame(raw_system_events)
-    df_final = df
-
-    result = {
-        "timestep": list(df_final["timestep"]),
-        "funding_pool": list(df_final["funding_pool"]),
-        "token_price": list(df_final["token_price"]),
-        "sentiment": list(df_final["sentiment"])
-    }
-    return result, df_final
-
-
 class TestParticipant(unittest.TestCase):
     def setUp(self):
         c = CommonsSimulationConfiguration(random_seed=1)
         results, df_final = get_simulation_results(c)
         self.df_final = df_final
-        PSUBs_labels = {}
-        for idx, block in enumerate(partial_state_update_blocks):
-            PSUBs_labels[idx+1] = block["label"]
 
-        self.PSUBs_labels = PSUBs_labels
 
     def test_participant_token_batch_age_is_updated_every_timestep(self):
             """
@@ -72,12 +39,19 @@ class TestParticipant(unittest.TestCase):
                 network = row["network"]
                 participants = get_participants(network)
 
-            participants_token_batch_ages = []
-            for i, participant in participants:
-                participants_token_batch_ages.append(participant.holdings.age_days)
-            # Check if the older token batch has the same age of the simulation
-            self.assertEqual(max(participants_token_batch_ages), timestep)
+                participants_token_batch_ages = []
+                for i, participant in participants:
+                    participants_token_batch_ages.append(participant.holdings.age_days)
+                # Check if the older token batch has the same age of the simulation
+                self.assertEqual(max(participants_token_batch_ages), timestep)
 
+
+class TestProposal(unittest.TestCase):
+    def setUp(self):
+        c = CommonsSimulationConfiguration(random_seed=1)
+        df = run_simulation(c)
+        self.df = df
+        
     def test_conviction_is_updated_once_by_timestep(self):
         for index, row in self.df_final.iterrows():
             timestep = row["timestep"]

--- a/simulation/integration_test.py
+++ b/simulation/integration_test.py
@@ -59,15 +59,15 @@ class TestProposal(unittest.TestCase):
     def test_conviction_is_updated_once_by_timestep(self):
         """
         Test that the Proposals' conviction is updated only once by timestep.
-        First it creates a new column on the result Data Frame with the psub
-        labels, and then check the behaviour of each psub. Only the psub
+        First, it creates a new column on the result Data Frame with the psub
+        labels, and then checks the behavior of each psub. Only the psub
         "Calculate proposals' conviction" updated the proposals' convictions.
         The psubs "Generate new participants" and "Generate new proposals" add
         new participants and proposals to the network, but should not affect
         the conviction of existing proposals. The psub
         "Participant decides if he wants to exit" removes participants from
         the network, thus it might remove proposals created by the removed
-        participants. This psub should not affect the remainig proposals'
+        participants. This psub should not affect the remaining proposals'
         conviction. The other psubs should not affect the proposals'
         conviction.
 

--- a/simulation/network_utils.py
+++ b/simulation/network_utils.py
@@ -291,3 +291,17 @@ def find_in_edges_of_type_for_proposal(network: nx.DiGraph, proposal_idx: int, e
             ans.append((participant_idx, proposal_idx, edge_type))
 
     return ans
+
+
+def get_proposals_conviction_list(network):
+    """
+    Convenience function. Return a list of proposals' conviction of
+    a given network.
+    """
+    support_edges = get_edges_by_type(network, "support")
+    conviction_list = []
+    for i, j in support_edges:
+        edge = network.edges[i, j]
+        conviction = edge["conviction"]
+        conviction_list.append(conviction)
+    return conviction_list

--- a/simulation/network_utils_test.py
+++ b/simulation/network_utils_test.py
@@ -10,7 +10,7 @@ from utils import new_probability_func, new_exponential_func, new_gamma_func, ne
 from network_utils import (add_proposal, add_participant, bootstrap_network, calc_avg_sentiment,
                            calc_median_affinity, calc_total_affinity, calc_total_conviction,
                            calc_total_funds_requested, find_in_edges_of_type_for_proposal, get_edges_by_type, get_edges_by_participant_and_type,
-                           get_participants, get_proposals,
+                           get_participants, get_proposals, get_proposals_conviction_list,
                            setup_conflict_edges, setup_influence_edges_bulk,
                            setup_influence_edges_single, setup_support_edges)
 
@@ -343,3 +343,13 @@ class TestNetworkUtils(unittest.TestCase):
         c_edges_expected = [(1, 9, 'conflict'), (3, 9, 'conflict'),
                             (5, 9, 'conflict'), (7, 9, 'conflict')]
         self.assertEqual(c_edges, c_edges_expected)
+
+    def test_get_proposals_conviction_list(self):
+        """
+        Test that the returning list of proposals' convictions is correct.
+        """
+        self.network = setup_support_edges(self.network, self.params["random_number_func"])
+        conviction_list = get_proposals_conviction_list(self.network)
+        expected_list = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        self.assertEqual(conviction_list, expected_list)

--- a/simulation/policies_test.py
+++ b/simulation/policies_test.py
@@ -93,7 +93,6 @@ class TestGenerateNewParticipant(unittest.TestCase):
             for u, v in network.in_edges(5):
                 self.assertEqual(network.edges[u, v]["type"], "influence")
 
-<<<<<<< HEAD
     def test_su_update_participants_token_batch_age(self):
         """
         Test that after running the state update function the participants'
@@ -106,8 +105,6 @@ class TestGenerateNewParticipant(unittest.TestCase):
         for i, participant in participants:
             self.assertEqual(participant.holdings.age_days, 1)
 
-=======
->>>>>>> c449d87da4dc718d10e22befbd748d8081321535
     def test_su_add_investment_to_commons(self):
         old_token_supply = self.commons._token_supply
         old_collateral_pool = self.commons._collateral_pool


### PR DESCRIPTION
This PR adds an integration test to ensure the proposals' convictions are updated only once per timestep. It also adds a convenience network function to return a list of all the proposals' convictions and the function's unit test.