### PR TITLE
Fix su_update_sentiment when status proposal fail or complete

### DIFF
--- a/simulation/entities.py
+++ b/simulation/entities.py
@@ -228,3 +228,4 @@ class ParticipantSupport(NamedTuple):
     affinity: float
     tokens: float = 0.
     conviction: float = 0.
+    is_author: bool = False

--- a/simulation/entities_test.py
+++ b/simulation/entities_test.py
@@ -229,7 +229,7 @@ class TestParticipantSupport(unittest.TestCase):
         Test that the it only has the fields currently used for defining 
         participant->proposal support edges
         """
-        self.assertEqual(self.pSupport._fields, ('affinity', 'tokens', 'conviction'))
+        self.assertEqual(self.pSupport._fields, ('affinity', 'tokens', 'conviction', 'is_author'))
 
     def test_default_values(self):
         """
@@ -238,3 +238,4 @@ class TestParticipantSupport(unittest.TestCase):
         self.assertEqual(self.pSupport.affinity, 1)
         self.assertEqual(self.pSupport.tokens, 0)
         self.assertEqual(self.pSupport.conviction, 0)
+        self.assertEqual(self.pSupport.is_author, False)


### PR DESCRIPTION
This PR introduces some changes to the `ParticipantExits.su_update_sentiment_when_proposal_becomes_failed_or_completed` state update function so when a proposal fails/completes, the sentiment is updated for both the owner and all participants who staked on that proposal, and proportional to the affinity they had for it.

This new behaviour makes the average sentiment to be more sensitive on how proposals evolve through the simulation and also introduces more pressure on selling tokens, so its price fluctuates instead of having a constantly increasing price trend.