### PR TITLE
Make participants with vesting unable to exit

### DIFF
--- a/simulation/entities.py
+++ b/simulation/entities.py
@@ -209,7 +209,7 @@ class Participant:
     def wants_to_exit(self):
         """
         Returns True if the Participant wants to exit (if sentiment < 0.5,
-        random chance of exiting) and if the Participant has no vesyting
+        random chance of exiting) and if the Participant has no vesting
         token, otherwise False.
         """
         sensitivity_exit = config.sentiment_sensitivity_exit

--- a/simulation/entities.py
+++ b/simulation/entities.py
@@ -209,9 +209,13 @@ class Participant:
     def wants_to_exit(self):
         """
         Returns True if the Participant wants to exit (if sentiment < 0.5,
-        random chance of exiting), otherwise False
+        random chance of exiting) and if the Participant has no vesyting
+        token, otherwise False.
         """
-        if self.sentiment < config.sentiment_sensitivity_exit:
+        sensitivity_exit = config.sentiment_sensitivity_exit
+        vesting = self.holdings.vesting
+
+        if self.sentiment < sensitivity_exit and vesting == 0:
             engagement_rate = config.engagement_rate_multiplier_exit * self.sentiment
             return self._probability_func(1-engagement_rate)
         return False

--- a/simulation/entities.py
+++ b/simulation/entities.py
@@ -97,7 +97,11 @@ class Participant:
         engagement_rate = config.engagement_rate_multiplier_sell * self.sentiment
         force = self.sentiment - config.sentiment_sensitivity
         if self._probability_func(engagement_rate) and force < 0:
-            delta_holdings = self._random_number_func() * force * self.holdings.spendable()
+            spendable = self.holdings.spendable()
+            # It is expected that the function returns a positive value for the
+            # amount sold. 
+            force = -1 * force 
+            delta_holdings = self._random_number_func() * force * spendable
             return delta_holdings
         return 0
 

--- a/simulation/entities_test.py
+++ b/simulation/entities_test.py
@@ -215,6 +215,10 @@ class TestParticipant(unittest.TestCase):
         # Set a sentiment below the exit threshold
         self.p.sentiment = 0.2
         self.p._probability_func = always
+        # A participant with vesting should not be able to exit
+        self.assertFalse(self.p.wants_to_exit())
+        self.p.holdings.vesting = 0
+        # After the participant have no vesting, he can exit
         self.assertTrue(self.p.wants_to_exit())
         self.p._probability_func = never
         self.assertFalse(self.p.wants_to_exit())
@@ -226,7 +230,7 @@ class TestParticipantSupport(unittest.TestCase):
 
     def test_available_fields(self):
         """
-        Test that the it only has the fields currently used for defining 
+        Test that the it only has the fields currently used for defining
         participant->proposal support edges
         """
         self.assertEqual(self.pSupport._fields, ('affinity', 'tokens', 'conviction', 'is_author'))

--- a/simulation/entities_test.py
+++ b/simulation/entities_test.py
@@ -218,7 +218,7 @@ class TestParticipant(unittest.TestCase):
         # A participant with vesting should not be able to exit
         self.assertFalse(self.p.wants_to_exit())
         self.p.holdings.vesting = 0
-        # After the participant have no vesting, he can exit
+        # After the participant has no vesting, he can exit
         self.assertTrue(self.p.wants_to_exit())
         self.p._probability_func = never
         self.assertFalse(self.p.wants_to_exit())

--- a/simulation/policies.py
+++ b/simulation/policies.py
@@ -448,7 +448,7 @@ class ParticipantSellsTokens:
             dai_returned, realized_price = commons2.burn(total_tokens)
 
             final_dai_distribution = {}
-            for i, participant in participants:
+            for i in ans:
                 final_dai_distribution[i] = ans[i] / total_tokens
 
             if params.get("debug"):
@@ -580,7 +580,7 @@ class ParticipantExits:
                             "sentiment_new": sentiment_new,
                             "status": status
                         }
-        
+
         if params.get("debug"):
             for i in report:
                 print(

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -72,8 +72,8 @@ class CommonsSimulationConfiguration:
                  kappa=2,
                  days_to_80p_of_max_voting_weight=10,
                  max_proposal_request=0.2,
-                 timesteps_days=100,
-                 random_seed=1):
+                 timesteps_days=730,
+                 random_seed=None):
         self.hatchers = hatchers
         self.proposals = proposals
         self.hatch_tribute = hatch_tribute

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -72,8 +72,8 @@ class CommonsSimulationConfiguration:
                  kappa=2,
                  days_to_80p_of_max_voting_weight=10,
                  max_proposal_request=0.2,
-                 timesteps_days=730,
-                 random_seed=None):
+                 timesteps_days=100,
+                 random_seed=1):
         self.hatchers = hatchers
         self.proposals = proposals
         self.hatch_tribute = hatch_tribute


### PR DESCRIPTION
This PR adds an additional condition to the Participant's method `wants_to_exit()` enabling only the participants without vesting to exit from the commons. This PR also updates the unit test `test_wants_to_exit()` according to the changes in `wants_to_exit()`.