### PR TITLE
Add sentiment decay state update function

### DIFF
--- a/simulation/config.py
+++ b/simulation/config.py
@@ -1,5 +1,5 @@
 # Participant Sentiment Parameters
-sentiment_decay = 0.01
+sentiment_decay = 0.005
 sentiment_sensitivity = 0.75
 candidate_proposals_cutoff = 0.75
 delta_holdings_scale = 10000

--- a/simulation/policies.py
+++ b/simulation/policies.py
@@ -592,7 +592,7 @@ class ParticipantSentiment:
     @staticmethod
     def su_update_sentiment_decay(params, step, sL, s, _input, **kwargs):
         network = s["network"]
-        
+
         participants = get_participants(network)
         for participant_idx, participant in participants:
             sentiment_old = network.nodes[participant_idx]["item"].sentiment

--- a/simulation/policies.py
+++ b/simulation/policies.py
@@ -586,3 +586,18 @@ class ParticipantExits:
                 print(
                     "ParticipantExits: Participant {} changed his sentiment from {} to {} because Proposal {} became {}".format(i, report[i]["sentiment_old"], report[i]["sentiment_new"], report[i]["proposal_idx"], report[i]["status"]))
         return "network", network
+
+
+class ParticipantSentiment:
+    @staticmethod
+    def su_update_sentiment_decay(params, step, sL, s, _input, **kwargs):
+        network = s["network"]
+        
+        participants = get_participants(network)
+        for participant_idx, participant in participants:
+            sentiment_old = network.nodes[participant_idx]["item"].sentiment
+            sentiment_new = sentiment_old - config.sentiment_decay
+            sentiment_new = 0 if sentiment_new < 0 else sentiment_new
+            network.nodes[participant_idx]["item"].sentiment = sentiment_new
+
+        return "network", network

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -6,7 +6,7 @@ from hatch import (create_token_batches, Commons,
 from entities import attrs
 from policies import (GenerateNewParticipant, GenerateNewProposal,
                       GenerateNewFunding, ActiveProposals, ProposalFunding,
-                      ParticipantVoting, ParticipantSellsTokens, 
+                      ParticipantVoting, ParticipantSellsTokens,
                       ParticipantBuysTokens, ParticipantExits,
                       ParticipantSentiment)
 from network_utils import bootstrap_network, calc_avg_sentiment

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -1,11 +1,17 @@
 from typing import Tuple
 import numpy as np
-from hatch import create_token_batches, TokenBatch, Commons, convert_80p_to_cliff_and_halflife
+from hatch import (create_token_batches, Commons,
+                   convert_80p_to_cliff_and_halflife)
 
 from entities import attrs
-from policies import GenerateNewParticipant, GenerateNewProposal, GenerateNewFunding, ActiveProposals, ProposalFunding, ParticipantVoting, ParticipantSellsTokens, ParticipantBuysTokens, ParticipantExits
+from policies import (GenerateNewParticipant, GenerateNewProposal,
+                      GenerateNewFunding, ActiveProposals, ProposalFunding,
+                      ParticipantVoting, ParticipantSellsTokens, 
+                      ParticipantBuysTokens, ParticipantExits,
+                      ParticipantSentiment)
 from network_utils import bootstrap_network, calc_avg_sentiment
-from utils import new_probability_func, new_exponential_func, new_gamma_func, new_random_number_func, new_choice_func
+from utils import (new_probability_func, new_exponential_func, new_gamma_func,
+                   new_random_number_func, new_choice_func)
 
 
 def update_collateral_pool(params, step, sL, s, _input):
@@ -137,7 +143,7 @@ def bootstrap_simulation(c: CommonsSimulationConfiguration):
         "token_supply": commons._token_supply,
         "token_price": commons.token_price(),
         "policy_output": None,
-        "sentiment": 0.5
+        "sentiment": 0.75
     }
 
     simulation_parameters = {
@@ -288,6 +294,13 @@ partial_state_update_blocks = [
         "variables": {
             "commons": ParticipantExits.su_burn_exiters_tokens,
             "network": ParticipantExits.su_remove_participants_from_network,
+        }
+    },
+    {
+        "label": "Participants' sentiment decays",
+        "policies": {},
+        "variables": {
+            "network": ParticipantSentiment.su_update_sentiment_decay,
         }
     },
     sync_state_variables


### PR DESCRIPTION
This PR adds a state update function that makes the sentiment of all the participants decay every timestep by a variable `sentiment_decay` defined in `config.py`. It also adds a unit test for the state update function and changes the initial sentiment to 0.75, which is the average sentiment of the hatchers.