### PR TITLE
Increase incoming people at vesting period

### DIFF
--- a/simulation/config.py
+++ b/simulation/config.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+
 # Participant Sentiment Parameters
 sentiment_decay = 0.005
 sentiment_sensitivity = 0.75
@@ -39,3 +42,7 @@ log_base05_of_02 = 2.321928094887362
 # GenerateNewParticipant Parameters
 arrival_rate_denominator = 10
 max_new_participants = 1
+
+# Speculation vesting
+speculation_days = 24 + int(72 * np.random.rand())
+multiplier_new_participants = 1 + int(9 * np.random.rand())

--- a/simulation/policies.py
+++ b/simulation/policies.py
@@ -17,6 +17,7 @@ class GenerateNewParticipant:
     def p_randomly(params, step, sL, s, **kwargs):
         commons = s["commons"]
         sentiment = s["sentiment"]
+        timestep = s["timestep"]
         probability_func = params["probability_func"]
         exponential_func = params["exponential_func"]
         ans = {
@@ -24,9 +25,17 @@ class GenerateNewParticipant:
             "new_participant_tokens": None
         }
         dict_ans = {}
+        
+        if timestep < config.speculation_days:
+            # If in speculation period, the arrival rate is higher
+            arrival_rate = 0.5 + 0.5 * sentiment
+            multiplier = config.multiplier_new_participants
+            max_new_participants = config.max_new_participants * multiplier
+        else:
+            arrival_rate = (1+sentiment)/config.arrival_rate_denominator
+            max_new_participants = config.max_new_participants
 
-        arrival_rate = (1+sentiment)/config.arrival_rate_denominator
-        for i in range(config.max_new_participants):
+        for i in range(max_new_participants):
             if probability_func(arrival_rate):
                 # Here we randomly generate each participant's post-Hatch
                 # investment, in DAI/USD.

--- a/simulation/policies_test.py
+++ b/simulation/policies_test.py
@@ -37,6 +37,7 @@ class TestGenerateNewParticipant(unittest.TestCase):
     def setUp(self):
         self.commons = Commons(10000, 1000)
         self.sentiment = 0.5
+        self.timestep = 200
         self.params = {
             "debug": False,
             "probability_func": new_probability_func(seed=None),
@@ -55,7 +56,8 @@ class TestGenerateNewParticipant(unittest.TestCase):
         """
         state = {
             "commons": self.commons,
-            "sentiment": self.sentiment
+            "sentiment": self.sentiment,
+            "timestep": self.timestep
         }
         self.params["probability_func"] = always
         ans = GenerateNewParticipant.p_randomly(self.params, 0, 0, state)[0]

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -13,6 +13,7 @@ from policies import (GenerateNewParticipant, GenerateNewProposal,
 from network_utils import bootstrap_network, calc_avg_sentiment
 from utils import (new_probability_func, new_exponential_func, new_gamma_func,
                    new_random_number_func, new_choice_func)
+import config
 
 
 def update_collateral_pool(params, step, sL, s, _input):

--- a/simulation/simulation.py
+++ b/simulation/simulation.py
@@ -13,7 +13,6 @@ from policies import (GenerateNewParticipant, GenerateNewProposal,
 from network_utils import bootstrap_network, calc_avg_sentiment
 from utils import (new_probability_func, new_exponential_func, new_gamma_func,
                    new_random_number_func, new_choice_func)
-import config
 
 
 def update_collateral_pool(params, step, sL, s, _input):


### PR DESCRIPTION
This PR fixes #76.
It adds a feature so that more people get into the commons during the vesting period. This period is called "speculation days" and can randomly vary from day 0 to day 20%-80%(24-96 days) of the period os vesting 80% locked. The multiplier of new incoming people can vary from 1 to 10.