### PR TITLE
Disable influence edges

### DIFF
--- a/simulation/network_utils.py
+++ b/simulation/network_utils.py
@@ -59,7 +59,7 @@ def add_proposal(network: nx.DiGraph, p: Proposal, random_number_func) -> Tuple[
 def add_participant(network: nx.DiGraph, p: Participant, exponential_func, random_number_func) -> Tuple[nx.DiGraph, int]:
     j = max(network.nodes) + 1
     network.add_node(j, item=p)
-    network = setup_influence_edges_single(network, j, exponential_func)
+    # network = setup_influence_edges_single(network, j, exponential_func) # TODO: Disabled as these aren't being used on any model policy
     network = setup_support_edges(network, random_number_func, j)
     return network, j
 
@@ -237,7 +237,7 @@ def bootstrap_network(n_participants: List[TokenBatch], n_proposals: int, fundin
 
     n = setup_support_edges(n, random_number_func)
     n = setup_conflict_edges(n, random_number_func)
-    n = setup_influence_edges_bulk(n, exponential_func)
+    # n = setup_influence_edges_bulk(n, exponential_func)  # TODO: Disabled as these aren't being used on any model policy
     return n
 
 

--- a/simulation/policies.py
+++ b/simulation/policies.py
@@ -8,8 +8,7 @@ from entities import Participant, Proposal, ProposalStatus
 from hatch import TokenBatch
 from network_utils import (add_proposal, add_participant, calc_median_affinity, calc_total_conviction,
                            calc_total_funds_requested, find_in_edges_of_type_for_proposal, get_edges_by_type,
-                           get_participants, get_proposals,
-                           setup_influence_edges_single, setup_support_edges)
+                           get_participants, get_proposals)
 
 
 class GenerateNewParticipant:


### PR DESCRIPTION
This disables the creation of influence edges between participants as these are currently unused. It should be enabled in a future when these edges are considered within the model policies